### PR TITLE
[Issue #3] Fix CI pipeline - add sbt setup action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
           java-version: '17'
           cache: 'sbt'
 
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
+
       - name: Compile
         run: sbt compile
 


### PR DESCRIPTION
## Summary
- Add `sbt/setup-sbt@v1` action to CI workflow to install sbt on GitHub Actions runner
- Fixes the "sbt: command not found" error that was causing CI to fail

## Changes
- Added sbt setup step after JDK setup and before compile step in `.github/workflows/ci.yml`

## Testing
- [x] Workflow syntax is valid YAML
- [x] No merge conflicts with master

## Issue
Closes #3

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)