### PR TITLE
[Issue #7] Remove redundant imports in ConstellationLanguageServer.scala

### DIFF
--- a/modules/lang-lsp/src/main/scala/io/constellation/lsp/ConstellationLanguageServer.scala
+++ b/modules/lang-lsp/src/main/scala/io/constellation/lsp/ConstellationLanguageServer.scala
@@ -12,7 +12,6 @@ import io.constellation.lang.parser.ConstellationParser
 import io.constellation.lsp.protocol.JsonRpc._
 import io.constellation.lsp.protocol.LspTypes._
 import io.constellation.lsp.protocol.LspMessages._
-import io.constellation.lsp.protocol.LspMessages.{GetDagStructureParams, GetDagStructureResult, DagStructure, ModuleNode, DataNode}
 
 /** Language server for constellation-lang with LSP support */
 class ConstellationLanguageServer(


### PR DESCRIPTION
## Summary
- Removed redundant explicit imports from `LspMessages` that were already covered by the wildcard import

## Changes
- Removed line 15: `import io.constellation.lsp.protocol.LspMessages.{GetDagStructureParams, GetDagStructureResult, DagStructure, ModuleNode, DataNode}`
- Kept the wildcard import on line 14: `import io.constellation.lsp.protocol.LspMessages._`

## Self-Review Notes
- Chose to keep the wildcard import style as it's consistent with other imports in the file (lines 5, 12, 13)
- The explicit imports were completely redundant since `._` already imports all members

## Testing
- [x] `sbt compile` passes
- [x] `sbt test` runs (note: 3 pre-existing failures in HoverContentTest unrelated to this change)
- [x] No merge conflicts with master

## Checklist
- [x] Code follows project conventions
- [x] No unnecessary changes outside issue scope
- [x] Single-line fix, minimal scope

Closes #7

---
Generated by Claude Agent 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)