### PR TITLE
[Issue #6] Fix "Empty message" error logging in WebSocket

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -76,7 +76,7 @@ This document tracks the current sprint issues and their status. **Agents update
 | [ ] | #3 | Fix CI pipeline - sbt command not found | Compiler | None | - |
 | [ ] | #4 | Add test coverage for lang-ast module | Compiler | None | - |
 | [ ] | #5 | Add test coverage for example-app modules | Compiler | None | - |
-| [ ] | #6 | Fix "Empty message" error logging in WebSocket | VSCode | None | - |
+| [~] | #6 | Fix "Empty message" error logging in WebSocket @agent-3 | VSCode | None | - |
 | [ ] | #7 | Remove redundant imports in LSP server | VSCode | None | - |
 
 ### P1 - High Priority (Target Completion)

--- a/modules/http-api/src/main/scala/io/constellation/http/LspWebSocketHandler.scala
+++ b/modules/http-api/src/main/scala/io/constellation/http/LspWebSocketHandler.scala
@@ -48,6 +48,7 @@ class LspWebSocketHandler(
             // Process incoming messages from client
             val processClientMessages: IO[Unit] =
               Stream.fromQueueUnterminated(clientMessages)
+                .filter(msg => msg.trim.nonEmpty) // Silently ignore empty messages (keep-alive pings)
                 .evalMap { message =>
                   parseMessage(message).flatMap {
                     case Left(request) =>


### PR DESCRIPTION
## Summary
- Filter empty WebSocket messages silently to prevent log pollution
- Root cause: Keep-alive pings or whitespace-only messages were triggering error logs

## Changes
- Added stream filter in `LspWebSocketHandler.scala` to ignore empty messages before parsing
- Updated `TODO.md` to mark issue #6 as in-progress

## Root Cause Analysis
Empty messages (after trimming whitespace) were being passed to `parseMessage()`, which raised an error. The error handler logged `[WS] Error processing message: Empty message` repeatedly during normal operation.

## Self-Review Notes
- Chose to filter at the stream level (before `evalMap`) for efficiency
- The fix is minimal and focused - single line addition
- The comment explains the purpose: "Silently ignore empty messages (keep-alive pings)"

## Testing
- [x] `sbt compile` passes
- [x] `sbt test` runs (3 pre-existing failures in HoverContentTest, unrelated to this change)
- [x] All http-api module tests pass
- [x] No merge conflicts with master

## Checklist
- [x] Code follows project conventions
- [x] No unnecessary changes outside issue scope
- [x] Edge cases handled (empty/whitespace-only messages filtered)
- [x] Minimal, focused fix

## Follow-up Issues Created
- #34 - [P3] Remove redundant empty message check in parseMessage

Closes #6

---
Generated by Claude Agent 3