### PR TITLE
[Issue #32] Fix failing HoverContentTest tests in lang-lsp

### DIFF
--- a/modules/lang-lsp/src/main/scala/io/constellation/lsp/TypeFormatter.scala
+++ b/modules/lang-lsp/src/main/scala/io/constellation/lsp/TypeFormatter.scala
@@ -35,9 +35,9 @@ object TypeFormatter {
     }
     val paramsStr = paramStrs.mkString(", ")
 
-    // Format return type
-    val returnStr = if (produces.size == 1 && produces.contains("out")) {
-      formatCType(produces("out"))
+    // Format return type - unwrap single-field records for cleaner display
+    val returnStr = if (produces.size == 1) {
+      formatCType(produces.values.head)
     } else {
       formatCType(CType.CProduct(produces))
     }
@@ -57,10 +57,10 @@ object TypeFormatter {
     }
   }
 
-  /** Format return type documentation */
+  /** Format return type documentation - unwrap single-field records for cleaner display */
   def formatReturns(produces: Map[String, CType]): String = {
-    if (produces.size == 1 && produces.contains("out")) {
-      s"`${formatCType(produces("out"))}`"
+    if (produces.size == 1) {
+      s"`${formatCType(produces.values.head)}`"
     } else {
       val fieldLines = produces.toList.sortBy(_._1).map { case (name, ctype) =>
         s"- **$name**: `${formatCType(ctype)}`"


### PR DESCRIPTION
## Summary
- Fix `TypeFormatter` to unwrap single-field records regardless of field name
- Previously only unwrapped fields named `"out"`, now unwraps any single-field record

## Changes
- `formatSignature`: Changed condition from `produces.size == 1 && produces.contains("out")` to `produces.size == 1`
- `formatReturns`: Same condition change
- Both methods now use `produces.values.head` instead of `produces("out")`

## Testing
- [x] `sbt compile` passes
- [x] All 10 HoverContentTest tests pass (previously 3 failing)
- [x] All 25 TypeFormatter-related tests pass
- [x] No regressions in other modules

## Note
There is 1 pre-existing failing test in `ResponseTest` ("should not include result field") that is unrelated to this change. This failure exists on master before any changes.

## Issue
Closes #32

---
Generated by Claude Agent 4