### PR TITLE
[Issue #11] Implement arithmetic operators (+, -, *, /)

### DIFF
--- a/modules/lang-ast/src/main/scala/io/constellation/lang/ast/AST.scala
+++ b/modules/lang-ast/src/main/scala/io/constellation/lang/ast/AST.scala
@@ -177,6 +177,13 @@ enum CompareOp:
   case LtEq    // <=
   case GtEq    // >=
 
+/** Arithmetic operators */
+enum ArithOp:
+  case Add     // +
+  case Sub     // -
+  case Mul     // *
+  case Div     // /
+
 /** Expressions */
 sealed trait Expression
 
@@ -231,6 +238,13 @@ object Expression {
   final case class Compare(
     left: Located[Expression],
     op: CompareOp,
+    right: Located[Expression]
+  ) extends Expression
+
+  /** Arithmetic expression: a + b, x * y, etc. */
+  final case class Arithmetic(
+    left: Located[Expression],
+    op: ArithOp,
     right: Located[Expression]
   ) extends Expression
 }
@@ -288,5 +302,9 @@ object CompileError {
 
   final case class UnsupportedComparison(op: String, leftType: String, rightType: String, span: Option[Span]) extends CompileError {
     def message: String = s"Operator '$op' is not supported for types $leftType and $rightType"
+  }
+
+  final case class UnsupportedArithmetic(op: String, leftType: String, rightType: String, span: Option[Span]) extends CompileError {
+    def message: String = s"Arithmetic operator '$op' is not supported for types $leftType and $rightType"
   }
 }

--- a/modules/lang-compiler/src/test/scala/io/constellation/lang/semantic/TypeCheckerTest.scala
+++ b/modules/lang-compiler/src/test/scala/io/constellation/lang/semantic/TypeCheckerTest.scala
@@ -387,7 +387,7 @@ class TypeCheckerTest extends AnyFlatSpec with Matchers {
     result.left.toOption.get.exists(_.isInstanceOf[CompileError.TypeError]) shouldBe true
   }
 
-  it should "report incompatible merge error" in {
+  it should "report unsupported arithmetic error for incompatible types" in {
     val source = """
       in a: Int
       in b: String
@@ -396,7 +396,8 @@ class TypeCheckerTest extends AnyFlatSpec with Matchers {
     """
     val result = check(source)
     result.isLeft shouldBe true
-    result.left.toOption.get.exists(_.isInstanceOf[CompileError.IncompatibleMerge]) shouldBe true
+    // + with non-numeric/non-record types produces UnsupportedArithmetic
+    result.left.toOption.get.exists(_.isInstanceOf[CompileError.UnsupportedArithmetic]) shouldBe true
   }
 
   it should "report conditional with non-boolean condition error" in {


### PR DESCRIPTION
## Summary
- Implement arithmetic operators (`+`, `-`, `*`, `/`) for numeric types in constellation-lang
- Add proper precedence handling (`*`, `/` before `+`, `-`)
- Disambiguate `+` between numeric addition and record merge based on operand types

## Changes
- **AST**: Add `ArithOp` enum (Add, Sub, Mul, Div) and `Arithmetic` expression node
- **Parser**: Add arithmetic operator parsing with correct precedence chain
- **TypeChecker**: Desugar arithmetic to stdlib function calls (`add`, `subtract`, `multiply`, `divide`)
- **TypeChecker**: For `+` with records/Candidates, preserve existing merge semantics
- **Errors**: Add `UnsupportedArithmetic` error for type mismatches
- **Tests**: Add comprehensive parser and type checker tests for all operators

## Type Rules
| Left | Right | Result |
|------|-------|--------|
| `Int` | `Int` | `Int` |
| `Float` | `Float` | `Float` |
| `Int` | `Float` | `Float` |
| `Record` | `Record` | Merge (for `+` only) |

## Self-Review Notes
- The `+` operator now produces `Arithmetic(Add, ...)` in the AST, and the TypeChecker determines whether to treat it as numeric addition or record merge based on operand types
- Existing record merge functionality is preserved via the `mergeTypes` method
- All 4 operators desugar to existing stdlib functions (`add`, `subtract`, `multiply`, `divide`)

## Testing
- [x] `sbt compile` passes
- [x] `sbt test` passes (all 252 tests)
- [x] Parser tests for all operators and precedence
- [x] Type checker tests for numeric and merge disambiguation

## Checklist
- [x] Code follows project conventions
- [x] No unnecessary changes outside issue scope
- [x] Edge cases handled (Candidates + Record, Record + Candidates)
- [x] Tests added for all new functionality

Closes #11

---
Generated by Claude Agent 1