### PR TITLE
feat(server): Add configurable port for multi-agent testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,22 @@ This file contains actionable rules that Claude must follow when working on this
 
 ## Server Endpoints
 
-- HTTP API: `http://localhost:8080`
-- LSP WebSocket: `ws://localhost:8080/lsp`
+- HTTP API: `http://localhost:{port}` (default: 8080)
+- LSP WebSocket: `ws://localhost:{port}/lsp`
 - Health check: `GET /health`
+
+**Port Configuration:**
+The server port is configurable via the `CONSTELLATION_PORT` environment variable.
+For multi-agent setups, each agent uses a unique port based on their agent number:
+
+| Agent | Port | Environment Variable |
+|-------|------|---------------------|
+| Main repo | 8080 | (default) |
+| Agent 1 | 8081 | `CONSTELLATION_PORT=8081` |
+| Agent 2 | 8082 | `CONSTELLATION_PORT=8082` |
+| Agent N | 8080+N | `CONSTELLATION_PORT=808N` |
+
+The `scripts/dev.ps1` script auto-detects the agent number from the directory name.
 
 ## Code Conventions
 
@@ -384,6 +397,41 @@ Assigned Issue: #<number> - <title>
 ```
 
 This helps the user track which agent is doing what.
+
+### Running Test Servers (Multi-Agent)
+
+Each agent can run their own server instance for testing without port conflicts.
+
+**Automatic port detection:**
+```powershell
+# In your worktree (e.g., constellation-agent-2), simply run:
+.\scripts\dev.ps1 -ServerOnly
+
+# The script auto-detects agent number from directory name:
+# constellation-agent-1 → port 8081
+# constellation-agent-2 → port 8082
+# etc.
+```
+
+**Manual port override:**
+```powershell
+# Explicit port
+.\scripts\dev.ps1 -ServerOnly -Port 8085
+
+# Or via environment variable
+$env:CONSTELLATION_PORT = 8085
+.\scripts\dev.ps1 -ServerOnly
+```
+
+**Accessing your agent's server:**
+```bash
+# Replace {port} with your agent's port
+curl http://localhost:{port}/health
+curl http://localhost:{port}/modules
+```
+
+**VSCode Extension:**
+When testing the VSCode extension, update the LSP port in `vscode-extension/.vscode/settings.json` or configure it per-agent.
 
 ---
 

--- a/modules/example-app/src/main/scala/io/constellation/examples/app/server/ExampleServer.scala
+++ b/modules/example-app/src/main/scala/io/constellation/examples/app/server/ExampleServer.scala
@@ -12,13 +12,16 @@ import io.constellation.http.ConstellationServer
   * This server demonstrates how to start a Constellation HTTP API server
   * with all available modules including DataModules and TextModules.
   *
+  * The server port can be configured via the CONSTELLATION_PORT environment variable.
+  * Default port is 8080. For multi-agent setups, use: 8080 + agent_number
+  *
   * Once started, you can:
   * - Compile constellation-lang programs: POST /compile
   * - Execute compiled DAGs: POST /execute
   * - List available DAGs: GET /dags
   * - List available modules: GET /modules
   * - Check server health: GET /health
-  * - Connect via WebSocket LSP: ws://localhost:8080/lsp
+  * - Connect via WebSocket LSP: ws://localhost:{port}/lsp
   */
 object ExampleServer extends IOApp.Simple {
 
@@ -35,12 +38,13 @@ object ExampleServer extends IOApp.Simple {
       // Create compiler with standard library + example app functions
       compiler = ExampleLib.compiler
 
-      // Start the HTTP server
-      _ <- IO.println("Constellation HTTP API server started at http://0.0.0.0:8080")
+      // Start the HTTP server (port from CONSTELLATION_PORT env var, defaults to 8080)
+      port = ConstellationServer.DefaultPort
+      _ <- IO.println(s"Constellation HTTP API server started at http://0.0.0.0:$port")
+      _ <- IO.println(s"  LSP WebSocket available at ws://localhost:$port/lsp")
       _ <- ConstellationServer
         .builder(constellation, compiler)
         .withHost("0.0.0.0")
-        .withPort(8080)
         .run
     } yield ()
   }

--- a/modules/http-api/src/main/scala/io/constellation/http/ConstellationServer.scala
+++ b/modules/http-api/src/main/scala/io/constellation/http/ConstellationServer.scala
@@ -34,10 +34,13 @@ import io.constellation.lang.semantic.FunctionRegistry
   */
 object ConstellationServer {
 
+  /** Default port, can be overridden via CONSTELLATION_PORT environment variable */
+  val DefaultPort: Int = sys.env.get("CONSTELLATION_PORT").flatMap(_.toIntOption).getOrElse(8080)
+
   /** Configuration for the HTTP server */
   case class Config(
     host: String = "0.0.0.0",
-    port: Int = 8080
+    port: Int = DefaultPort
   )
 
   /** Builder for creating a Constellation HTTP server */


### PR DESCRIPTION
## Summary
- Allows each agent to run their own server instance without port conflicts
- Port auto-detection from worktree directory name (agent-N → port 808N)
- Documented in CLAUDE.md for all agents

## Changes

### `ConstellationServer.scala`
- Added `DefaultPort` that reads from `CONSTELLATION_PORT` environment variable
- Falls back to 8080 if not set

### `ExampleServer.scala`
- Uses `ConstellationServer.DefaultPort` instead of hardcoded 8080
- Displays dynamic port in startup messages

### `scripts/dev.ps1`
- Added `-Port` parameter for explicit port override
- Added `Get-ServerPort` function with auto-detection logic:
  1. Explicit `-Port` parameter
  2. Directory name detection (`constellation-agent-N` → port `808N`)
  3. `CONSTELLATION_PORT` environment variable
  4. Default: 8080
- Sets environment variable before starting sbt job

### `CLAUDE.md`
- Updated Server Endpoints section with port configuration table
- Added "Running Test Servers (Multi-Agent)" section with usage examples

## Usage

```powershell
# Auto-detect from directory (in constellation-agent-2 → port 8082)
.\scripts\dev.ps1 -ServerOnly

# Explicit port
.\scripts\dev.ps1 -ServerOnly -Port 8085

# Environment variable
$env:CONSTELLATION_PORT = 8083
sbt "exampleApp/run"
```

## Testing
- [x] `sbt compile` passes
- [x] Verified port detection logic

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)