### PR TITLE
[Issue #16] Implement Optional type for nullable values

### DIFF
--- a/modules/lang-compiler/src/main/scala/io/constellation/lang/semantic/SemanticType.scala
+++ b/modules/lang-compiler/src/main/scala/io/constellation/lang/semantic/SemanticType.scala
@@ -47,6 +47,11 @@ object SemanticType {
     def prettyPrint: String = s"Map<${key.prettyPrint}, ${value.prettyPrint}>"
   }
 
+  /** Optional<T> - represents a value that may or may not exist */
+  final case class SOptional(inner: SemanticType) extends SemanticType {
+    def prettyPrint: String = s"Optional<${inner.prettyPrint}>"
+  }
+
   /** Convert SemanticType to Constellation CType */
   def toCType(st: SemanticType): CType = st match {
     case SString => CType.CString
@@ -57,6 +62,7 @@ object SemanticType {
     case SCandidates(elem) => CType.CList(toCType(elem))
     case SList(elem) => CType.CList(toCType(elem))
     case SMap(k, v) => CType.CMap(toCType(k), toCType(v))
+    case SOptional(inner) => CType.COptional(toCType(inner))
   }
 
   /** Convert Constellation CType to SemanticType */
@@ -69,6 +75,7 @@ object SemanticType {
     case CType.CMap(k, v) => SMap(fromCType(k), fromCType(v))
     case CType.CProduct(fields) => SRecord(fields.view.mapValues(fromCType).toMap)
     case CType.CUnion(fields) => SRecord(fields.view.mapValues(fromCType).toMap)
+    case CType.COptional(inner) => SOptional(fromCType(inner))
   }
 }
 

--- a/modules/lang-compiler/src/main/scala/io/constellation/lang/semantic/TypeChecker.scala
+++ b/modules/lang-compiler/src/main/scala/io/constellation/lang/semantic/TypeChecker.scala
@@ -246,6 +246,8 @@ object TypeChecker {
         case "Map" if params.size == 2 =>
           (resolveTypeExpr(params(0), span, env), resolveTypeExpr(params(1), span, env))
             .mapN(SemanticType.SMap(_, _))
+        case "Optional" if params.size == 1 =>
+          resolveTypeExpr(params.head, span, env).map(SemanticType.SOptional(_))
         case _ =>
           CompileError.UndefinedType(s"$name<...>", Some(span)).invalidNel
       }

--- a/modules/lang-lsp/src/main/scala/io/constellation/lsp/ConstellationLanguageServer.scala
+++ b/modules/lang-lsp/src/main/scala/io/constellation/lsp/ConstellationLanguageServer.scala
@@ -366,6 +366,8 @@ class ConstellationLanguageServer(
       s"{ ${structure.map { case (k, v) => s"$k: ${cTypeToString(v)}" }.mkString(", ")} }"
     case io.constellation.CType.CUnion(structure) =>
       structure.keys.mkString(" | ")
+    case io.constellation.CType.COptional(innerType) =>
+      s"Optional<${cTypeToString(innerType)}>"
   }
 
   private def typeExprToDescriptor(typeExpr: TypeExpr): TypeDescriptor = typeExpr match {
@@ -799,6 +801,8 @@ class ConstellationLanguageServer(
         k.asInstanceOf[CString].value -> cvalueToJson(v)
       })
       case CUnion(value, _, tag) => Json.obj("tag" -> Json.fromString(tag), "value" -> cvalueToJson(value))
+      case CSome(value, _) => cvalueToJson(value)
+      case CNone(_) => Json.Null
     }
   }
 

--- a/modules/lang-lsp/src/main/scala/io/constellation/lsp/TypeFormatter.scala
+++ b/modules/lang-lsp/src/main/scala/io/constellation/lsp/TypeFormatter.scala
@@ -21,6 +21,8 @@ object TypeFormatter {
         s"$name: ${formatCType(typ)}"
       }
       s"(${fieldStrs.mkString(" | ")})"
+    case CType.COptional(inner) =>
+      s"Optional<${formatCType(inner)}>"
   }
 
   /** Format function signature from ModuleNodeSpec */

--- a/modules/runtime/src/main/scala/io/constellation/CustomJsonCodecs.scala
+++ b/modules/runtime/src/main/scala/io/constellation/CustomJsonCodecs.scala
@@ -49,6 +49,8 @@ trait CustomJsonCodecs {
       Json.obj("tag" -> "CProduct".asJson, "structure" -> structure.asJson)
     case CType.CUnion(structure) =>
       Json.obj("tag" -> "CUnion".asJson, "structure" -> structure.asJson)
+    case CType.COptional(innerType) =>
+      Json.obj("tag" -> "COptional".asJson, "innerType" -> innerType.asJson)
   }
 
   given ctypeDecoder: Decoder[CType] = Decoder.instance { c =>
@@ -64,6 +66,7 @@ trait CustomJsonCodecs {
       } yield CType.CMap(keysType, valuesType)
       case "CProduct" => c.downField("structure").as[Map[String, CType]].map(CType.CProduct.apply)
       case "CUnion" => c.downField("structure").as[Map[String, CType]].map(CType.CUnion.apply)
+      case "COptional" => c.downField("innerType").as[CType].map(CType.COptional.apply)
       case other => Left(io.circe.DecodingFailure(s"Unknown CType tag: $other", c.history))
     }
   }

--- a/modules/runtime/src/main/scala/io/constellation/JsonCValueConverter.scala
+++ b/modules/runtime/src/main/scala/io/constellation/JsonCValueConverter.scala
@@ -147,6 +147,14 @@ object JsonCValueConverter {
             }
           case None => Left(fieldError(path, s"expected Object with 'tag' and 'value', got ${jsonTypeName(json)}"))
         }
+
+      case CType.COptional(innerType) =>
+        // null or missing field is None, otherwise convert inner value
+        if (json.isNull) {
+          Right(CValue.CNone(innerType))
+        } else {
+          jsonToCValue(json, innerType, path).map(v => CValue.CSome(v, innerType))
+        }
     }
   }
 
@@ -190,6 +198,9 @@ object JsonCValueConverter {
         "tag" -> Json.fromString(tag),
         "value" -> cValueToJson(value)
       )
+
+    case CValue.CSome(value, _) => cValueToJson(value)
+    case CValue.CNone(_) => Json.Null
   }
 
   /** Build field path for error reporting */

--- a/modules/runtime/src/main/scala/io/constellation/Runtime.scala
+++ b/modules/runtime/src/main/scala/io/constellation/Runtime.scala
@@ -68,6 +68,10 @@ final case class Runtime(table: Runtime.MutableDataTable, state: Runtime.Mutable
       }.map(_.toMap)
     case CValue.CUnion(value, _, tag) =>
       cValueToAny(value).map(v => (tag, v))
+    case CValue.CSome(value, _) =>
+      cValueToAny(value).map(Some(_))
+    case CValue.CNone(_) =>
+      IO.pure(None)
   }
 }
 


### PR DESCRIPTION
## Summary
- Implements the `Optional` wrapper type for values that may or may not exist
- Adds `COptional` type and `CSome`/`CNone` values to the core type system
- Enables `Optional<T>` type syntax in constellation-lang
- Foundation for guard expressions (#15) and coalesce operator (#17)

## Changes
- `modules/core/.../TypeSystem.scala`: Added `COptional` type, `CSome`/`CNone` values, and Scala `Option[A]` interop
- `modules/lang-compiler/.../SemanticType.scala`: Added `SOptional` semantic type with CType conversion
- `modules/lang-compiler/.../TypeChecker.scala`: Added parsing for `Optional<T>` type expressions
- `modules/runtime/.../Runtime.scala`: Added conversion of CSome/CNone to Scala Option
- `modules/runtime/.../CustomJsonCodecs.scala`: Added JSON encoding/decoding for COptional
- `modules/runtime/.../JsonCValueConverter.scala`: Added JSON↔CValue conversion for Optional (null = None)
- `modules/lang-lsp/.../TypeFormatter.scala`: Added pretty printing for Optional types
- `modules/lang-lsp/.../ConstellationLanguageServer.scala`: Added Optional type display and JSON output

## Self-Review Notes
- Followed existing patterns for type system extension (CList, CMap)
- JSON null → CNone, non-null → CSome for intuitive API usage
- Added comprehensive unit tests covering:
  - CTypeTag derivation for Option types
  - CValueInjector for Some/None
  - CValueExtractor for CSome/CNone
  - CValue.ctype reporting
  - Roundtrip inject/extract
  - JSON conversion in both directions

## Testing
- [x] `sbt compile` passes
- [x] `sbt testOnly io.constellation.TypeSystemTest io.constellation.http.JsonCValueConverterTest` passes (49 tests)
- [x] All existing tests pass (verified earlier in session)

## Checklist
- [x] Code follows project conventions
- [x] No unnecessary changes outside issue scope
- [x] Edge cases handled (null JSON, nested Optionals)
- [x] Tests added for all new functionality

Closes #16

---
Generated by Claude Agent 4