### PR TITLE
feat(viz): implement DagVizIR and Sugiyama layout algorithm

### DIFF
--- a/modules/example-app/src/main/scala/io/constellation/examples/app/ExampleLib.scala
+++ b/modules/example-app/src/main/scala/io/constellation/examples/app/ExampleLib.scala
@@ -276,5 +276,8 @@ object ExampleLib {
           }
         result.copy(syntheticModules = result.syntheticModules ++ neededModules)
       }
+
+    def compileToIR(source: String, dagName: String) =
+      underlying.compileToIR(source, dagName)
   }
 }

--- a/modules/lang-compiler/src/main/scala/io/constellation/lang/CachingLangCompiler.scala
+++ b/modules/lang-compiler/src/main/scala/io/constellation/lang/CachingLangCompiler.scala
@@ -2,7 +2,7 @@ package io.constellation.lang
 
 import cats.effect.unsafe.implicits.global
 import io.constellation.lang.ast.CompileError
-import io.constellation.lang.compiler.CompileResult
+import io.constellation.lang.compiler.{CompileResult, IRProgram}
 import io.constellation.lang.semantic.FunctionRegistry
 
 /** A LangCompiler wrapper that caches compilation results.
@@ -46,6 +46,10 @@ class CachingLangCompiler(
         result
     }
   }
+
+  def compileToIR(source: String, dagName: String): Either[List[CompileError], IRProgram] =
+    // Delegate to underlying compiler (no caching for IR - it's used for visualization)
+    underlying.compileToIR(source, dagName)
 
   /** Get cache statistics */
   def cacheStats: CacheStats =

--- a/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/DagVizCompiler.scala
+++ b/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/DagVizCompiler.scala
@@ -1,0 +1,305 @@
+package io.constellation.lang.viz
+
+import io.constellation.lang.compiler.{IRNode, IRProgram, HigherOrderOp}
+import io.constellation.lang.semantic.SemanticType
+
+import java.util.UUID
+
+/** Compiles an IRProgram into a DagVizIR for visualization */
+object DagVizCompiler:
+
+  /** Compile an IR program to visualization IR
+    *
+    * @param ir The compiled IR program
+    * @param title Optional title for the visualization
+    * @return DagVizIR ready for layout
+    */
+  def compile(ir: IRProgram, title: Option[String] = None): DagVizIR =
+    val nodeMap = ir.nodes
+
+    // Build reverse mapping: variable name -> node ID for outputs
+    val outputNodeIds = ir.declaredOutputs.flatMap { name =>
+      ir.variableBindings.get(name).map(id => (name, id))
+    }.toMap
+
+    // Convert each IR node to a VizNode
+    val vizNodes = nodeMap.map { case (id, node) =>
+      val outputName = outputNodeIds.collectFirst { case (name, nodeId) if nodeId == id => name }
+      irNodeToVizNode(id, node, outputName)
+    }.toList
+
+    // Build edges from dependencies
+    val vizEdges = buildEdges(ir)
+
+    DagVizIR(
+      nodes = vizNodes,
+      edges = vizEdges,
+      groups = List.empty, // Groups computed later if needed
+      metadata = VizMetadata(title = title)
+    )
+
+  /** Convert an IR node to a visualization node */
+  private def irNodeToVizNode(id: UUID, node: IRNode, outputName: Option[String]): VizNode =
+    val baseNode = node match {
+      case IRNode.Input(_, name, outputType, _) =>
+        VizNode(
+          id = id.toString,
+          kind = NodeKind.Input,
+          label = name,
+          typeSignature = formatType(outputType)
+        )
+
+      case IRNode.ModuleCall(_, moduleName, languageName, inputs, outputType, _) =>
+        VizNode(
+          id = id.toString,
+          kind = NodeKind.Operation,
+          label = languageName,
+          typeSignature = formatType(outputType)
+        )
+
+      case IRNode.MergeNode(_, _, _, outputType, _) =>
+        VizNode(
+          id = id.toString,
+          kind = NodeKind.Merge,
+          label = "+",
+          typeSignature = formatType(outputType)
+        )
+
+      case IRNode.ProjectNode(_, _, fields, outputType, _) =>
+        VizNode(
+          id = id.toString,
+          kind = NodeKind.Project,
+          label = s"[${fields.take(3).mkString(", ")}${if fields.length > 3 then ", ..." else ""}]",
+          typeSignature = formatType(outputType)
+        )
+
+      case IRNode.FieldAccessNode(_, _, field, outputType, _) =>
+        VizNode(
+          id = id.toString,
+          kind = NodeKind.FieldAccess,
+          label = s".$field",
+          typeSignature = formatType(outputType)
+        )
+
+      case IRNode.ConditionalNode(_, _, _, _, outputType, _) =>
+        VizNode(
+          id = id.toString,
+          kind = NodeKind.Conditional,
+          label = "if/else",
+          typeSignature = formatType(outputType)
+        )
+
+      case IRNode.LiteralNode(_, value, outputType, _) =>
+        VizNode(
+          id = id.toString,
+          kind = NodeKind.Literal,
+          label = formatLiteralValue(value),
+          typeSignature = formatType(outputType)
+        )
+
+      case IRNode.AndNode(_, _, _, _) =>
+        VizNode(
+          id = id.toString,
+          kind = NodeKind.BooleanOp,
+          label = "AND",
+          typeSignature = "Boolean"
+        )
+
+      case IRNode.OrNode(_, _, _, _) =>
+        VizNode(
+          id = id.toString,
+          kind = NodeKind.BooleanOp,
+          label = "OR",
+          typeSignature = "Boolean"
+        )
+
+      case IRNode.NotNode(_, _, _) =>
+        VizNode(
+          id = id.toString,
+          kind = NodeKind.BooleanOp,
+          label = "NOT",
+          typeSignature = "Boolean"
+        )
+
+      case IRNode.GuardNode(_, _, _, innerType, _) =>
+        VizNode(
+          id = id.toString,
+          kind = NodeKind.Guard,
+          label = "when",
+          typeSignature = s"Optional<${formatType(innerType)}>"
+        )
+
+      case IRNode.CoalesceNode(_, _, _, resultType, _) =>
+        VizNode(
+          id = id.toString,
+          kind = NodeKind.Coalesce,
+          label = "??",
+          typeSignature = formatType(resultType)
+        )
+
+      case IRNode.BranchNode(_, cases, _, resultType, _) =>
+        VizNode(
+          id = id.toString,
+          kind = NodeKind.Branch,
+          label = s"branch (${cases.length} cases)",
+          typeSignature = formatType(resultType)
+        )
+
+      case IRNode.StringInterpolationNode(_, _, _, _) =>
+        VizNode(
+          id = id.toString,
+          kind = NodeKind.StringInterp,
+          label = "interpolate",
+          typeSignature = "String"
+        )
+
+      case IRNode.HigherOrderNode(_, operation, _, _, outputType, _) =>
+        val opName = operation match {
+          case HigherOrderOp.Filter => "filter"
+          case HigherOrderOp.Map    => "map"
+          case HigherOrderOp.All    => "all"
+          case HigherOrderOp.Any    => "any"
+          case HigherOrderOp.SortBy => "sortBy"
+        }
+        VizNode(
+          id = id.toString,
+          kind = NodeKind.HigherOrder,
+          label = opName,
+          typeSignature = formatType(outputType)
+        )
+
+      case IRNode.ListLiteralNode(_, elements, elementType, _) =>
+        VizNode(
+          id = id.toString,
+          kind = NodeKind.ListLiteral,
+          label = s"[${elements.length} items]",
+          typeSignature = s"List<${formatType(elementType)}>"
+        )
+    }
+
+    // Mark as output if this node is a declared output
+    outputName match {
+      case Some(name) =>
+        baseNode.copy(
+          kind = NodeKind.Output,
+          label = name
+        )
+      case None => baseNode
+    }
+
+  /** Build edges from IR dependencies */
+  private def buildEdges(ir: IRProgram): List[VizEdge] =
+    var edgeId = 0
+    def nextEdgeId(): String =
+      edgeId += 1
+      s"e$edgeId"
+
+    ir.nodes.flatMap { case (targetId, node) =>
+      node match {
+        case IRNode.Input(_, _, _, _) =>
+          List.empty
+
+        case IRNode.ModuleCall(_, _, _, inputs, _, _) =>
+          inputs.map { case (paramName, sourceId) =>
+            VizEdge(
+              id = nextEdgeId(),
+              source = sourceId.toString,
+              target = targetId.toString,
+              label = Some(paramName),
+              kind = EdgeKind.Data
+            )
+          }.toList
+
+        case IRNode.MergeNode(_, left, right, _, _) =>
+          List(
+            VizEdge(nextEdgeId(), left.toString, targetId.toString, Some("left"), EdgeKind.Data),
+            VizEdge(nextEdgeId(), right.toString, targetId.toString, Some("right"), EdgeKind.Data)
+          )
+
+        case IRNode.ProjectNode(_, source, _, _, _) =>
+          List(VizEdge(nextEdgeId(), source.toString, targetId.toString, None, EdgeKind.Data))
+
+        case IRNode.FieldAccessNode(_, source, _, _, _) =>
+          List(VizEdge(nextEdgeId(), source.toString, targetId.toString, None, EdgeKind.Data))
+
+        case IRNode.ConditionalNode(_, cond, thenBr, elseBr, _, _) =>
+          List(
+            VizEdge(nextEdgeId(), cond.toString, targetId.toString, Some("cond"), EdgeKind.Control),
+            VizEdge(nextEdgeId(), thenBr.toString, targetId.toString, Some("then"), EdgeKind.Data),
+            VizEdge(nextEdgeId(), elseBr.toString, targetId.toString, Some("else"), EdgeKind.Data)
+          )
+
+        case IRNode.LiteralNode(_, _, _, _) =>
+          List.empty
+
+        case IRNode.AndNode(_, left, right, _) =>
+          List(
+            VizEdge(nextEdgeId(), left.toString, targetId.toString, Some("left"), EdgeKind.Control),
+            VizEdge(nextEdgeId(), right.toString, targetId.toString, Some("right"), EdgeKind.Control)
+          )
+
+        case IRNode.OrNode(_, left, right, _) =>
+          List(
+            VizEdge(nextEdgeId(), left.toString, targetId.toString, Some("left"), EdgeKind.Control),
+            VizEdge(nextEdgeId(), right.toString, targetId.toString, Some("right"), EdgeKind.Control)
+          )
+
+        case IRNode.NotNode(_, operand, _) =>
+          List(VizEdge(nextEdgeId(), operand.toString, targetId.toString, None, EdgeKind.Control))
+
+        case IRNode.GuardNode(_, expr, condition, _, _) =>
+          List(
+            VizEdge(nextEdgeId(), expr.toString, targetId.toString, Some("expr"), EdgeKind.Data),
+            VizEdge(nextEdgeId(), condition.toString, targetId.toString, Some("cond"), EdgeKind.Control)
+          )
+
+        case IRNode.CoalesceNode(_, left, right, _, _) =>
+          List(
+            VizEdge(nextEdgeId(), left.toString, targetId.toString, Some("value"), EdgeKind.Optional),
+            VizEdge(nextEdgeId(), right.toString, targetId.toString, Some("default"), EdgeKind.Data)
+          )
+
+        case IRNode.BranchNode(_, cases, otherwise, _, _) =>
+          val caseEdges = cases.zipWithIndex.flatMap { case ((condId, exprId), idx) =>
+            List(
+              VizEdge(nextEdgeId(), condId.toString, targetId.toString, Some(s"cond$idx"), EdgeKind.Control),
+              VizEdge(nextEdgeId(), exprId.toString, targetId.toString, Some(s"case$idx"), EdgeKind.Data)
+            )
+          }
+          caseEdges :+ VizEdge(nextEdgeId(), otherwise.toString, targetId.toString, Some("otherwise"), EdgeKind.Data)
+
+        case IRNode.StringInterpolationNode(_, _, expressions, _) =>
+          expressions.zipWithIndex.map { case (exprId, idx) =>
+            VizEdge(nextEdgeId(), exprId.toString, targetId.toString, Some(s"expr$idx"), EdgeKind.Data)
+          }
+
+        case IRNode.HigherOrderNode(_, _, source, _, _, _) =>
+          List(VizEdge(nextEdgeId(), source.toString, targetId.toString, Some("source"), EdgeKind.Data))
+
+        case IRNode.ListLiteralNode(_, elements, _, _) =>
+          elements.zipWithIndex.map { case (elemId, idx) =>
+            VizEdge(nextEdgeId(), elemId.toString, targetId.toString, Some(s"[$idx]"), EdgeKind.Data)
+          }
+      }
+    }.toList
+
+  /** Format a type for display, abbreviating long record types */
+  private def formatType(t: SemanticType): String =
+    t match {
+      case SemanticType.SRecord(fields) if fields.size > 3 =>
+        val shown = fields.take(3).map { case (n, t) => s"$n: ${formatType(t)}" }.mkString(", ")
+        s"{ $shown, ... +${fields.size - 3} }"
+      case other =>
+        other.prettyPrint
+    }
+
+  /** Format a literal value for display */
+  private def formatLiteralValue(value: Any): String =
+    value match {
+      case s: String if s.length > 20 => s""""${s.take(20)}...""""
+      case s: String                  => s""""$s""""
+      case n: Number                  => n.toString
+      case b: Boolean                 => b.toString
+      case null                       => "null"
+      case other                      => other.toString.take(20)
+    }

--- a/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/DagVizIR.scala
+++ b/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/DagVizIR.scala
@@ -1,0 +1,144 @@
+package io.constellation.lang.viz
+
+import io.circe.{Decoder, Encoder, Json}
+import io.circe.generic.semiauto.*
+
+/** Node kinds for DAG visualization */
+enum NodeKind:
+  case Input         // External data entering the DAG
+  case Output        // Declared output of the DAG
+  case Operation     // Module call / function invocation
+  case Literal       // Literal value (string, int, etc.)
+  case Merge         // Record merge operation (+)
+  case Project       // Field projection ([field1, field2])
+  case FieldAccess   // Single field access (.field)
+  case Conditional   // If/else expression
+  case Guard         // Guard expression (expr when cond)
+  case Branch        // Multi-way branch expression
+  case Coalesce      // Null coalescing (??)
+  case HigherOrder   // Higher-order operations (map, filter, etc.)
+  case ListLiteral   // List literal expression
+  case BooleanOp     // AND, OR, NOT operations
+  case StringInterp  // String interpolation
+
+object NodeKind:
+  given Encoder[NodeKind] = Encoder.encodeString.contramap(_.toString)
+  given Decoder[NodeKind] = Decoder.decodeString.emap { s =>
+    NodeKind.values.find(_.toString == s).toRight(s"Unknown NodeKind: $s")
+  }
+
+/** Edge kinds for DAG visualization */
+enum EdgeKind:
+  case Data     // Normal data flow
+  case Optional // Optional data flow (from guard expressions)
+  case Control  // Control flow (conditions)
+
+object EdgeKind:
+  given Encoder[EdgeKind] = Encoder.encodeString.contramap(_.toString)
+  given Decoder[EdgeKind] = Decoder.decodeString.emap { s =>
+    EdgeKind.values.find(_.toString == s).toRight(s"Unknown EdgeKind: $s")
+  }
+
+/** Execution status for runtime visualization */
+enum ExecutionStatus:
+  case Pending   // Not yet executed
+  case Running   // Currently executing
+  case Completed // Successfully completed
+  case Failed    // Execution failed
+
+object ExecutionStatus:
+  given Encoder[ExecutionStatus] = Encoder.encodeString.contramap(_.toString)
+  given Decoder[ExecutionStatus] = Decoder.decodeString.emap { s =>
+    ExecutionStatus.values.find(_.toString == s).toRight(s"Unknown ExecutionStatus: $s")
+  }
+
+/** Position in 2D space for layout */
+case class Position(x: Double, y: Double)
+
+object Position:
+  given Encoder[Position] = deriveEncoder
+  given Decoder[Position] = deriveDecoder
+
+/** Execution state attached to nodes after execution */
+case class ExecutionState(
+    status: ExecutionStatus,
+    value: Option[Json] = None,
+    durationMs: Option[Long] = None,
+    error: Option[String] = None
+)
+
+object ExecutionState:
+  given Encoder[ExecutionState] = deriveEncoder
+  given Decoder[ExecutionState] = deriveDecoder
+
+/** A node in the visualization DAG */
+case class VizNode(
+    id: String,
+    kind: NodeKind,
+    label: String,                            // Display name (e.g., "FetchCustomer", "order")
+    typeSignature: String,                    // Human-readable type (e.g., "{ id: String, name: String }")
+    position: Option[Position] = None,        // Computed by layout engine
+    executionState: Option[ExecutionState] = None
+)
+
+object VizNode:
+  given Encoder[VizNode] = deriveEncoder
+  given Decoder[VizNode] = deriveDecoder
+
+/** An edge connecting two nodes */
+case class VizEdge(
+    id: String,
+    source: String, // Source node ID
+    target: String, // Target node ID
+    label: Option[String] = None, // Parameter name for module inputs
+    kind: EdgeKind = EdgeKind.Data
+)
+
+object VizEdge:
+  given Encoder[VizEdge] = deriveEncoder
+  given Decoder[VizEdge] = deriveDecoder
+
+/** A group of nodes (for collapsible sections) */
+case class NodeGroup(
+    id: String,
+    label: String,
+    nodeIds: List[String],
+    collapsed: Boolean = false
+)
+
+object NodeGroup:
+  given Encoder[NodeGroup] = deriveEncoder
+  given Decoder[NodeGroup] = deriveDecoder
+
+/** Bounding box for the visualization */
+case class Bounds(minX: Double, minY: Double, maxX: Double, maxY: Double)
+
+object Bounds:
+  given Encoder[Bounds] = deriveEncoder
+  given Decoder[Bounds] = deriveDecoder
+
+/** Metadata about the visualization */
+case class VizMetadata(
+    title: Option[String] = None,
+    layoutDirection: String = "TB", // "TB" (top-bottom) or "LR" (left-right)
+    bounds: Option[Bounds] = None
+)
+
+object VizMetadata:
+  given Encoder[VizMetadata] = deriveEncoder
+  given Decoder[VizMetadata] = deriveDecoder
+
+/** The complete DAG visualization intermediate representation */
+case class DagVizIR(
+    nodes: List[VizNode],
+    edges: List[VizEdge],
+    groups: List[NodeGroup] = List.empty,
+    metadata: VizMetadata = VizMetadata()
+)
+
+object DagVizIR:
+  given Encoder[DagVizIR] = deriveEncoder
+  given Decoder[DagVizIR] = deriveDecoder
+
+  /** Create an empty DAG */
+  val empty: DagVizIR = DagVizIR(List.empty, List.empty)

--- a/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/SugiyamaLayout.scala
+++ b/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/SugiyamaLayout.scala
@@ -1,0 +1,236 @@
+package io.constellation.lang.viz
+
+/** Configuration for the Sugiyama layout algorithm */
+case class LayoutConfig(
+    direction: String = "TB",   // "TB" (top-bottom) or "LR" (left-right)
+    nodeWidth: Double = 180,    // Default node width
+    nodeHeight: Double = 60,    // Default node height
+    nodeSpacing: Double = 40,   // Horizontal spacing within a layer
+    layerSpacing: Double = 100  // Vertical spacing between layers
+)
+
+/** Sugiyama layout algorithm for DAG visualization
+  *
+  * The algorithm works in three phases:
+  * 1. Layer Assignment - assign each node to a layer using longest path
+  * 2. Crossing Minimization - reorder nodes within layers to minimize edge crossings
+  * 3. Position Assignment - compute x,y coordinates
+  */
+object SugiyamaLayout:
+
+  /** Apply Sugiyama layout to a DAG
+    *
+    * @param dag The DAG to layout (nodes without positions)
+    * @param config Layout configuration
+    * @return DAG with positions assigned to all nodes
+    */
+  def layout(dag: DagVizIR, config: LayoutConfig = LayoutConfig()): DagVizIR =
+    if dag.nodes.isEmpty then return dag
+
+    // Build adjacency lists
+    val (successors, predecessors) = buildAdjacencyLists(dag)
+
+    // Phase 1: Layer assignment
+    val nodeLayers = assignLayers(dag.nodes, successors, predecessors)
+
+    // Phase 2: Crossing minimization
+    val orderedLayers = minimizeCrossings(nodeLayers, successors, predecessors)
+
+    // Phase 3: Position assignment
+    val positions = assignPositions(orderedLayers, config)
+
+    // Update nodes with positions
+    val positionedNodes = dag.nodes.map { node =>
+      positions.get(node.id) match {
+        case Some(pos) => node.copy(position = Some(pos))
+        case None      => node
+      }
+    }
+
+    // Calculate bounds
+    val bounds = calculateBounds(positions.values.toList, config)
+
+    dag.copy(
+      nodes = positionedNodes,
+      metadata = dag.metadata.copy(
+        layoutDirection = config.direction,
+        bounds = Some(bounds)
+      )
+    )
+
+  /** Build successor and predecessor adjacency lists */
+  private def buildAdjacencyLists(dag: DagVizIR): (Map[String, List[String]], Map[String, List[String]]) =
+    val successors = dag.edges
+      .groupBy(_.source)
+      .view
+      .mapValues(_.map(_.target).toList)
+      .toMap
+      .withDefaultValue(List.empty)
+
+    val predecessors = dag.edges
+      .groupBy(_.target)
+      .view
+      .mapValues(_.map(_.source).toList)
+      .toMap
+      .withDefaultValue(List.empty)
+
+    (successors, predecessors)
+
+  /** Assign nodes to layers using longest path from sources
+    *
+    * Sources (nodes with no predecessors) are at layer 0.
+    * Each other node is placed at max(predecessor layers) + 1.
+    */
+  private def assignLayers(
+      nodes: List[VizNode],
+      successors: Map[String, List[String]],
+      predecessors: Map[String, List[String]]
+  ): Map[Int, List[VizNode]] =
+    val nodeById = nodes.map(n => n.id -> n).toMap
+
+    // Find sources (no predecessors)
+    val sources = nodes.filter(n => predecessors(n.id).isEmpty).map(_.id)
+
+    // BFS/topological order to assign layers
+    var layerOf = Map.empty[String, Int]
+    var queue = sources.toList
+    var visited = Set.empty[String]
+
+    // Initialize sources at layer 0
+    sources.foreach(id => layerOf = layerOf + (id -> 0))
+
+    // Process in topological order
+    while queue.nonEmpty do
+      val current = queue.head
+      queue = queue.tail
+
+      if !visited.contains(current) then
+        visited = visited + current
+        val currentLayer = layerOf.getOrElse(current, 0)
+
+        // Update successors
+        for succ <- successors(current) do
+          val newLayer = currentLayer + 1
+          val existingLayer = layerOf.getOrElse(succ, 0)
+          layerOf = layerOf + (succ -> math.max(existingLayer, newLayer))
+
+          // Add to queue if all predecessors visited
+          if predecessors(succ).forall(visited.contains) then
+            queue = queue :+ succ
+
+    // Handle any unvisited nodes (cycles or disconnected)
+    val unvisited = nodes.filterNot(n => visited.contains(n.id))
+    val maxLayer = if layerOf.isEmpty then 0 else layerOf.values.max
+    unvisited.foreach(n => layerOf = layerOf + (n.id -> (maxLayer + 1)))
+
+    // Group nodes by layer
+    nodes
+      .groupBy(n => layerOf.getOrElse(n.id, 0))
+      .view
+      .mapValues(_.toList)
+      .toMap
+
+  /** Minimize edge crossings using barycenter heuristic
+    *
+    * Iteratively reorders nodes within each layer based on the
+    * average position of their neighbors in adjacent layers.
+    */
+  private def minimizeCrossings(
+      layers: Map[Int, List[VizNode]],
+      successors: Map[String, List[String]],
+      predecessors: Map[String, List[String]]
+  ): Map[Int, List[VizNode]] =
+    if layers.isEmpty then return layers
+
+    val maxLayer = layers.keys.max
+    var orderedLayers = layers
+
+    // Multiple passes for better results
+    for _ <- 0 until 4 do
+      // Forward pass (top to bottom)
+      for layer <- 1 to maxLayer do
+        orderedLayers = reorderLayer(orderedLayers, layer, predecessors, forward = true)
+
+      // Backward pass (bottom to top)
+      for layer <- (maxLayer - 1) to 0 by -1 do
+        orderedLayers = reorderLayer(orderedLayers, layer, successors, forward = false)
+
+    orderedLayers
+
+  /** Reorder a single layer based on neighbor positions */
+  private def reorderLayer(
+      layers: Map[Int, List[VizNode]],
+      layerIndex: Int,
+      adjacency: Map[String, List[String]], // predecessors or successors
+      forward: Boolean
+  ): Map[Int, List[VizNode]] =
+    val currentLayer = layers.getOrElse(layerIndex, List.empty)
+    val adjacentLayerIndex = if forward then layerIndex - 1 else layerIndex + 1
+    val adjacentLayer = layers.getOrElse(adjacentLayerIndex, List.empty)
+
+    if adjacentLayer.isEmpty then return layers
+
+    // Create position map for adjacent layer
+    val adjacentPositions = adjacentLayer.zipWithIndex.map { case (n, i) => n.id -> i.toDouble }.toMap
+
+    // Calculate barycenter for each node in current layer
+    val barycenters = currentLayer.map { node =>
+      val neighbors = adjacency(node.id).filter(adjacentPositions.contains)
+      val barycenter = if neighbors.isEmpty then
+        // Keep relative position if no neighbors
+        currentLayer.indexOf(node).toDouble
+      else
+        neighbors.map(adjacentPositions).sum / neighbors.length
+      (node, barycenter)
+    }
+
+    // Sort by barycenter
+    val reordered = barycenters.sortBy(_._2).map(_._1)
+    layers + (layerIndex -> reordered)
+
+  /** Assign x,y positions to nodes */
+  private def assignPositions(
+      layers: Map[Int, List[VizNode]],
+      config: LayoutConfig
+  ): Map[String, Position] =
+    val isHorizontal = config.direction == "LR"
+
+    layers.flatMap { case (layerIndex, nodes) =>
+      val layerSize = nodes.length
+      val totalWidth = layerSize * config.nodeWidth + (layerSize - 1) * config.nodeSpacing
+
+      nodes.zipWithIndex.map { case (node, indexInLayer) =>
+        // Center nodes in their layer
+        val offset = indexInLayer * (config.nodeWidth + config.nodeSpacing)
+        val centered = offset - totalWidth / 2 + config.nodeWidth / 2
+
+        val pos = if isHorizontal then
+          Position(
+            x = layerIndex * (config.nodeWidth + config.layerSpacing),
+            y = centered
+          )
+        else
+          Position(
+            x = centered,
+            y = layerIndex * (config.nodeHeight + config.layerSpacing)
+          )
+
+        node.id -> pos
+      }
+    }
+
+  /** Calculate bounding box for the visualization */
+  private def calculateBounds(positions: List[Position], config: LayoutConfig): Bounds =
+    if positions.isEmpty then
+      Bounds(0, 0, config.nodeWidth, config.nodeHeight)
+    else
+      val xs = positions.map(_.x)
+      val ys = positions.map(_.y)
+      val padding = 20
+
+      Bounds(
+        minX = xs.min - config.nodeWidth / 2 - padding,
+        minY = ys.min - config.nodeHeight / 2 - padding,
+        maxX = xs.max + config.nodeWidth / 2 + padding,
+        maxY = ys.max + config.nodeHeight / 2 + padding
+      )

--- a/modules/lang-compiler/src/test/scala/io/constellation/lang/CompilationCacheTest.scala
+++ b/modules/lang-compiler/src/test/scala/io/constellation/lang/CompilationCacheTest.scala
@@ -190,6 +190,7 @@ class CompilationCacheTest extends AnyFlatSpec with Matchers {
         compileCount += 1
         Right(mockCompileResult(dagName))
       }
+      def compileToIR(source: String, dagName: String) = Left(List.empty)
     }
 
     val cache    = CompilationCache.createUnsafe()
@@ -211,6 +212,7 @@ class CompilationCacheTest extends AnyFlatSpec with Matchers {
         compileCount += 1
         Right(mockCompileResult(dagName))
       }
+      def compileToIR(source: String, dagName: String) = Left(List.empty)
     }
 
     val cache    = CompilationCache.createUnsafe()
@@ -231,6 +233,7 @@ class CompilationCacheTest extends AnyFlatSpec with Matchers {
         compileCount += 1
         Right(mockCompileResult(dagName))
       }
+      def compileToIR(source: String, dagName: String) = Left(List.empty)
     }
 
     val cache    = CompilationCache.createUnsafe()
@@ -251,6 +254,7 @@ class CompilationCacheTest extends AnyFlatSpec with Matchers {
         compileCount += 1
         Left(List(io.constellation.lang.ast.CompileError.InternalError("test error")))
       }
+      def compileToIR(source: String, dagName: String) = Left(List.empty)
     }
 
     val cache    = CompilationCache.createUnsafe()
@@ -272,6 +276,7 @@ class CompilationCacheTest extends AnyFlatSpec with Matchers {
         compileCount += 1
         Right(mockCompileResult(dagName))
       }
+      def compileToIR(source: String, dagName: String) = Left(List.empty)
     }
 
     val cache    = CompilationCache.createUnsafe()
@@ -296,6 +301,7 @@ class CompilationCacheTest extends AnyFlatSpec with Matchers {
         compileCount += 1
         Right(mockCompileResult(dagName))
       }
+      def compileToIR(source: String, dagName: String) = Left(List.empty)
     }
 
     val cache    = CompilationCache.createUnsafe()

--- a/modules/lang-compiler/src/test/scala/io/constellation/lang/viz/DagVizCompilerTest.scala
+++ b/modules/lang-compiler/src/test/scala/io/constellation/lang/viz/DagVizCompilerTest.scala
@@ -1,0 +1,204 @@
+package io.constellation.lang.viz
+
+import io.constellation.lang.compiler.{IRNode, IRProgram}
+import io.constellation.lang.semantic.SemanticType
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.util.UUID
+
+class DagVizCompilerTest extends AnyFunSuite with Matchers {
+
+  test("compile simple input node") {
+    val inputId = UUID.randomUUID()
+    val ir = IRProgram(
+      nodes = Map(
+        inputId -> IRNode.Input(inputId, "data", SemanticType.SString, None)
+      ),
+      inputs = List(inputId),
+      declaredOutputs = List.empty,
+      variableBindings = Map("data" -> inputId)
+    )
+
+    val vizIR = DagVizCompiler.compile(ir)
+
+    vizIR.nodes should have length 1
+    vizIR.nodes.head.kind shouldBe NodeKind.Input
+    vizIR.nodes.head.label shouldBe "data"
+    vizIR.nodes.head.typeSignature shouldBe "String"
+    vizIR.edges should be(empty)
+  }
+
+  test("compile linear pipeline A -> B -> C") {
+    val inputId = UUID.randomUUID()
+    val moduleId = UUID.randomUUID()
+    val outputId = UUID.randomUUID()
+
+    val ir = IRProgram(
+      nodes = Map(
+        inputId -> IRNode.Input(inputId, "input", SemanticType.SString, None),
+        moduleId -> IRNode.ModuleCall(
+          moduleId,
+          "Uppercase",
+          "Uppercase",
+          Map("text" -> inputId),
+          SemanticType.SString,
+          None
+        ),
+        outputId -> IRNode.FieldAccessNode(outputId, moduleId, "result", SemanticType.SString, None)
+      ),
+      inputs = List(inputId),
+      declaredOutputs = List("result"),
+      variableBindings = Map("input" -> inputId, "processed" -> moduleId, "result" -> outputId)
+    )
+
+    val vizIR = DagVizCompiler.compile(ir)
+
+    vizIR.nodes should have length 3
+    vizIR.edges should have length 2
+
+    // Check node types
+    val nodeKinds = vizIR.nodes.map(n => n.id -> n.kind).toMap
+    nodeKinds(inputId.toString) shouldBe NodeKind.Input
+    nodeKinds(moduleId.toString) shouldBe NodeKind.Operation
+    nodeKinds(outputId.toString) shouldBe NodeKind.Output // Marked as output because it's in declaredOutputs
+
+    // Check edges exist
+    val edgePairs = vizIR.edges.map(e => (e.source, e.target)).toSet
+    edgePairs should contain((inputId.toString, moduleId.toString))
+    edgePairs should contain((moduleId.toString, outputId.toString))
+  }
+
+  test("compile diamond pattern") {
+    // A -> B, A -> C, B -> D, C -> D
+    val aId = UUID.randomUUID()
+    val bId = UUID.randomUUID()
+    val cId = UUID.randomUUID()
+    val dId = UUID.randomUUID()
+
+    val ir = IRProgram(
+      nodes = Map(
+        aId -> IRNode.Input(aId, "a", SemanticType.SString, None),
+        bId -> IRNode.ModuleCall(bId, "ModuleB", "ModuleB", Map("x" -> aId), SemanticType.SString, None),
+        cId -> IRNode.ModuleCall(cId, "ModuleC", "ModuleC", Map("x" -> aId), SemanticType.SString, None),
+        dId -> IRNode.MergeNode(dId, bId, cId, SemanticType.SRecord(Map("b" -> SemanticType.SString, "c" -> SemanticType.SString)), None)
+      ),
+      inputs = List(aId),
+      declaredOutputs = List.empty,
+      variableBindings = Map("a" -> aId, "b" -> bId, "c" -> cId, "d" -> dId)
+    )
+
+    val vizIR = DagVizCompiler.compile(ir)
+
+    vizIR.nodes should have length 4
+    vizIR.edges should have length 4 // a->b, a->c, b->d, c->d
+
+    val nodeKinds = vizIR.nodes.map(n => n.id -> n.kind).toMap
+    nodeKinds(aId.toString) shouldBe NodeKind.Input
+    nodeKinds(bId.toString) shouldBe NodeKind.Operation
+    nodeKinds(cId.toString) shouldBe NodeKind.Operation
+    nodeKinds(dId.toString) shouldBe NodeKind.Merge
+  }
+
+  test("compile with literal node") {
+    val literalId = UUID.randomUUID()
+    val ir = IRProgram(
+      nodes = Map(
+        literalId -> IRNode.LiteralNode(literalId, 42, SemanticType.SInt, None)
+      ),
+      inputs = List.empty,
+      declaredOutputs = List.empty,
+      variableBindings = Map("x" -> literalId)
+    )
+
+    val vizIR = DagVizCompiler.compile(ir)
+
+    vizIR.nodes should have length 1
+    vizIR.nodes.head.kind shouldBe NodeKind.Literal
+    vizIR.nodes.head.label shouldBe "42"
+  }
+
+  test("compile with guard node") {
+    val inputId = UUID.randomUUID()
+    val condId = UUID.randomUUID()
+    val guardId = UUID.randomUUID()
+
+    val ir = IRProgram(
+      nodes = Map(
+        inputId -> IRNode.Input(inputId, "value", SemanticType.SInt, None),
+        condId -> IRNode.LiteralNode(condId, true, SemanticType.SBoolean, None),
+        guardId -> IRNode.GuardNode(guardId, inputId, condId, SemanticType.SInt, None)
+      ),
+      inputs = List(inputId),
+      declaredOutputs = List.empty,
+      variableBindings = Map("value" -> inputId, "guarded" -> guardId)
+    )
+
+    val vizIR = DagVizCompiler.compile(ir)
+
+    vizIR.nodes should have length 3
+    val guardNode = vizIR.nodes.find(_.id == guardId.toString).get
+    guardNode.kind shouldBe NodeKind.Guard
+    guardNode.typeSignature shouldBe "Optional<Int>"
+  }
+
+  test("compile with record type abbreviation") {
+    val inputId = UUID.randomUUID()
+    val recordType = SemanticType.SRecord(Map(
+      "field1" -> SemanticType.SString,
+      "field2" -> SemanticType.SInt,
+      "field3" -> SemanticType.SFloat,
+      "field4" -> SemanticType.SBoolean,
+      "field5" -> SemanticType.SString
+    ))
+
+    val ir = IRProgram(
+      nodes = Map(
+        inputId -> IRNode.Input(inputId, "data", recordType, None)
+      ),
+      inputs = List(inputId),
+      declaredOutputs = List.empty,
+      variableBindings = Map("data" -> inputId)
+    )
+
+    val vizIR = DagVizCompiler.compile(ir)
+
+    // Should abbreviate to show 3 fields + count
+    vizIR.nodes.head.typeSignature should include("...")
+    vizIR.nodes.head.typeSignature should include("+2")
+  }
+
+  test("edge labels for module parameters") {
+    val input1Id = UUID.randomUUID()
+    val input2Id = UUID.randomUUID()
+    val moduleId = UUID.randomUUID()
+
+    val ir = IRProgram(
+      nodes = Map(
+        input1Id -> IRNode.Input(input1Id, "a", SemanticType.SInt, None),
+        input2Id -> IRNode.Input(input2Id, "b", SemanticType.SInt, None),
+        moduleId -> IRNode.ModuleCall(
+          moduleId,
+          "Add",
+          "add",
+          Map("left" -> input1Id, "right" -> input2Id),
+          SemanticType.SInt,
+          None
+        )
+      ),
+      inputs = List(input1Id, input2Id),
+      declaredOutputs = List.empty,
+      variableBindings = Map("a" -> input1Id, "b" -> input2Id, "sum" -> moduleId)
+    )
+
+    val vizIR = DagVizCompiler.compile(ir)
+
+    // Find edges going to the module
+    val moduleEdges = vizIR.edges.filter(_.target == moduleId.toString)
+    moduleEdges should have length 2
+
+    val labels = moduleEdges.flatMap(_.label).toSet
+    labels should contain("left")
+    labels should contain("right")
+  }
+}

--- a/modules/lang-compiler/src/test/scala/io/constellation/lang/viz/SugiyamaLayoutTest.scala
+++ b/modules/lang-compiler/src/test/scala/io/constellation/lang/viz/SugiyamaLayoutTest.scala
@@ -1,0 +1,219 @@
+package io.constellation.lang.viz
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class SugiyamaLayoutTest extends AnyFunSuite with Matchers {
+
+  private def makeNode(id: String, kind: NodeKind = NodeKind.Operation): VizNode =
+    VizNode(id, kind, s"Node$id", "String", None, None)
+
+  private def makeEdge(source: String, target: String): VizEdge =
+    VizEdge(s"e-$source-$target", source, target, None, EdgeKind.Data)
+
+  test("layout single node") {
+    val dag = DagVizIR(
+      nodes = List(makeNode("A", NodeKind.Input)),
+      edges = List.empty
+    )
+
+    val result = SugiyamaLayout.layout(dag)
+
+    result.nodes should have length 1
+    result.nodes.head.position shouldBe defined
+    result.metadata.bounds shouldBe defined
+  }
+
+  test("layout linear pipeline A -> B -> C") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNode("A", NodeKind.Input),
+        makeNode("B"),
+        makeNode("C", NodeKind.Output)
+      ),
+      edges = List(
+        makeEdge("A", "B"),
+        makeEdge("B", "C")
+      )
+    )
+
+    val result = SugiyamaLayout.layout(dag)
+
+    // All nodes should have positions
+    result.nodes.foreach { node =>
+      node.position shouldBe defined
+    }
+
+    // Nodes should be in different layers (different y coordinates for TB layout)
+    val positions = result.nodes.map(n => n.id -> n.position.get).toMap
+    positions("A").y should be < positions("B").y
+    positions("B").y should be < positions("C").y
+  }
+
+  test("layout diamond pattern") {
+    // A -> B, A -> C, B -> D, C -> D
+    val dag = DagVizIR(
+      nodes = List(
+        makeNode("A", NodeKind.Input),
+        makeNode("B"),
+        makeNode("C"),
+        makeNode("D", NodeKind.Output)
+      ),
+      edges = List(
+        makeEdge("A", "B"),
+        makeEdge("A", "C"),
+        makeEdge("B", "D"),
+        makeEdge("C", "D")
+      )
+    )
+
+    val result = SugiyamaLayout.layout(dag)
+
+    val positions = result.nodes.map(n => n.id -> n.position.get).toMap
+
+    // A should be at top (layer 0)
+    // B and C should be at same layer (layer 1)
+    // D should be at bottom (layer 2)
+    positions("A").y should be < positions("B").y
+    positions("A").y should be < positions("C").y
+    positions("B").y shouldBe positions("C").y
+    positions("B").y should be < positions("D").y
+    positions("C").y should be < positions("D").y
+  }
+
+  test("layout respects left-right direction") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNode("A", NodeKind.Input),
+        makeNode("B", NodeKind.Output)
+      ),
+      edges = List(makeEdge("A", "B"))
+    )
+
+    val config = LayoutConfig(direction = "LR")
+    val result = SugiyamaLayout.layout(dag, config)
+
+    val positions = result.nodes.map(n => n.id -> n.position.get).toMap
+
+    // For LR, x increases instead of y
+    positions("A").x should be < positions("B").x
+
+    result.metadata.layoutDirection shouldBe "LR"
+  }
+
+  test("layout multiple inputs at same layer") {
+    // A1, A2 -> B
+    val dag = DagVizIR(
+      nodes = List(
+        makeNode("A1", NodeKind.Input),
+        makeNode("A2", NodeKind.Input),
+        makeNode("B", NodeKind.Output)
+      ),
+      edges = List(
+        makeEdge("A1", "B"),
+        makeEdge("A2", "B")
+      )
+    )
+
+    val result = SugiyamaLayout.layout(dag)
+
+    val positions = result.nodes.map(n => n.id -> n.position.get).toMap
+
+    // A1 and A2 should be on same layer (same y)
+    positions("A1").y shouldBe positions("A2").y
+    // Both should be above B
+    positions("A1").y should be < positions("B").y
+    // A1 and A2 should have different x positions
+    positions("A1").x should not be positions("A2").x
+  }
+
+  test("layout calculates correct bounds") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNode("A", NodeKind.Input),
+        makeNode("B"),
+        makeNode("C", NodeKind.Output)
+      ),
+      edges = List(
+        makeEdge("A", "B"),
+        makeEdge("B", "C")
+      )
+    )
+
+    val result = SugiyamaLayout.layout(dag)
+
+    result.metadata.bounds shouldBe defined
+    val bounds = result.metadata.bounds.get
+
+    // Bounds should encompass all nodes
+    result.nodes.foreach { node =>
+      val pos = node.position.get
+      pos.x should be >= bounds.minX
+      pos.x should be <= bounds.maxX
+      pos.y should be >= bounds.minY
+      pos.y should be <= bounds.maxY
+    }
+  }
+
+  test("layout handles empty dag") {
+    val dag = DagVizIR(nodes = List.empty, edges = List.empty)
+    val result = SugiyamaLayout.layout(dag)
+    result.nodes shouldBe empty
+  }
+
+  test("layout with custom config") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNode("A", NodeKind.Input),
+        makeNode("B", NodeKind.Output)
+      ),
+      edges = List(makeEdge("A", "B"))
+    )
+
+    val config = LayoutConfig(
+      direction = "TB",
+      nodeWidth = 200,
+      nodeHeight = 80,
+      nodeSpacing = 60,
+      layerSpacing = 120
+    )
+
+    val result = SugiyamaLayout.layout(dag, config)
+
+    val positions = result.nodes.map(n => n.id -> n.position.get).toMap
+
+    // Layer spacing should affect y distance
+    val yDiff = positions("B").y - positions("A").y
+    yDiff should be >= config.layerSpacing
+  }
+
+  test("crossing minimization improves layout") {
+    // Create a dag where naive ordering would have more crossings
+    // A1 -> B2, A2 -> B1 (crossing if A1,A2 and B1,B2 in that order)
+    val dag = DagVizIR(
+      nodes = List(
+        makeNode("A1", NodeKind.Input),
+        makeNode("A2", NodeKind.Input),
+        makeNode("B1"),
+        makeNode("B2")
+      ),
+      edges = List(
+        makeEdge("A1", "B2"),
+        makeEdge("A2", "B1")
+      )
+    )
+
+    val result = SugiyamaLayout.layout(dag)
+
+    val positions = result.nodes.map(n => n.id -> n.position.get).toMap
+
+    // After crossing minimization, if A1 is left of A2,
+    // then B2 should be left of B1 (to minimize crossing)
+    // Or vice versa
+    val a1Left = positions("A1").x < positions("A2").x
+    val b2Left = positions("B2").x < positions("B1").x
+
+    // They should match (both left or both right) to avoid crossing
+    a1Left shouldBe b2Left
+  }
+}

--- a/modules/lang-lsp/src/main/scala/io/constellation/lsp/protocol/LspMessages.scala
+++ b/modules/lang-lsp/src/main/scala/io/constellation/lsp/protocol/LspMessages.scala
@@ -204,6 +204,69 @@ object LspMessages {
       cType: String
   )
 
+  // ========== Custom: Get DAG Visualization (New Format) ==========
+
+  case class GetDagVisualizationParams(
+      uri: String,
+      direction: Option[String] = None,    // "TB" or "LR", defaults to "TB"
+      executionId: Option[String] = None   // If provided, include execution state
+  )
+
+  case class GetDagVisualizationResult(
+      success: Boolean,
+      dag: Option[DagVisualization],
+      error: Option[String] = None
+  )
+
+  /** Complete DAG visualization with layout */
+  case class DagVisualization(
+      nodes: List[DagVizNode],
+      edges: List[DagVizEdge],
+      groups: List[DagVizGroup],
+      metadata: DagVizMetadata
+  )
+
+  case class DagVizNode(
+      id: String,
+      kind: String,           // "Input", "Output", "Operation", etc.
+      label: String,
+      typeSignature: String,
+      position: Option[DagVizPosition],
+      executionState: Option[DagVizExecutionState]
+  )
+
+  case class DagVizEdge(
+      id: String,
+      source: String,
+      target: String,
+      label: Option[String],
+      kind: String            // "Data", "Optional", "Control"
+  )
+
+  case class DagVizGroup(
+      id: String,
+      label: String,
+      nodeIds: List[String],
+      collapsed: Boolean
+  )
+
+  case class DagVizPosition(x: Double, y: Double)
+
+  case class DagVizBounds(minX: Double, minY: Double, maxX: Double, maxY: Double)
+
+  case class DagVizMetadata(
+      title: Option[String],
+      layoutDirection: String,
+      bounds: Option[DagVizBounds]
+  )
+
+  case class DagVizExecutionState(
+      status: String,               // "Pending", "Running", "Completed", "Failed"
+      value: Option[Json],
+      durationMs: Option[Long],
+      error: Option[String]
+  )
+
   case class InputField(
       name: String,
       `type`: TypeDescriptor,
@@ -362,6 +425,37 @@ object LspMessages {
 
   given Encoder[DataNode] = deriveEncoder
   given Decoder[DataNode] = deriveDecoder
+
+  // DAG Visualization codecs
+  given Encoder[GetDagVisualizationParams] = deriveEncoder
+  given Decoder[GetDagVisualizationParams] = deriveDecoder
+
+  given Encoder[GetDagVisualizationResult] = deriveEncoder
+  given Decoder[GetDagVisualizationResult] = deriveDecoder
+
+  given Encoder[DagVisualization] = deriveEncoder
+  given Decoder[DagVisualization] = deriveDecoder
+
+  given Encoder[DagVizNode] = deriveEncoder
+  given Decoder[DagVizNode] = deriveDecoder
+
+  given Encoder[DagVizEdge] = deriveEncoder
+  given Decoder[DagVizEdge] = deriveDecoder
+
+  given Encoder[DagVizGroup] = deriveEncoder
+  given Decoder[DagVizGroup] = deriveDecoder
+
+  given Encoder[DagVizPosition] = deriveEncoder
+  given Decoder[DagVizPosition] = deriveDecoder
+
+  given Encoder[DagVizBounds] = deriveEncoder
+  given Decoder[DagVizBounds] = deriveDecoder
+
+  given Encoder[DagVizMetadata] = deriveEncoder
+  given Decoder[DagVizMetadata] = deriveDecoder
+
+  given Encoder[DagVizExecutionState] = deriveEncoder
+  given Decoder[DagVizExecutionState] = deriveDecoder
 
   given Encoder[RecordField] = deriveEncoder
   given Decoder[RecordField] = deriveDecoder

--- a/modules/lang-stdlib/src/main/scala/io/constellation/stdlib/StdLib.scala
+++ b/modules/lang-stdlib/src/main/scala/io/constellation/stdlib/StdLib.scala
@@ -93,5 +93,8 @@ object StdLib
           }
         result.copy(syntheticModules = result.syntheticModules ++ neededStdModules)
       }
+
+    def compileToIR(source: String, dagName: String) =
+      underlying.compileToIR(source, dagName)
   }
 }


### PR DESCRIPTION
## Summary

- Implements Phase 1 of DAG visualization infrastructure for constellation-lang
- Adds `DagVizIR` data types with comprehensive JSON codecs for all node/edge types
- Adds `DagVizCompiler` to transform `IRProgram` to visualization-ready IR
- Implements Sugiyama layout algorithm with crossing minimization for automatic node positioning
- Adds `getDagVisualization` LSP endpoint for editor integration

## Changes

### Core IR (`DagVizIR.scala`)
- `NodeKind` enum: Input, Output, Operation, Literal, Merge, Project, FieldAccess, Conditional, Guard, Branch, Coalesce, HigherOrder, ListLiteral, BooleanOp, StringInterp
- `EdgeKind` enum: Data, Optional, Control
- `ExecutionStatus` and `ExecutionState` for runtime visualization
- `Position`, `Bounds`, `VizNode`, `VizEdge`, `NodeGroup`, `VizMetadata` types
- Complete Circe JSON codecs for all types

### DagVizCompiler (`DagVizCompiler.scala`)
- Transforms IRProgram to DagVizIR
- Maps all IRNode types to appropriate NodeKind
- Builds edges from IR dependencies with parameter labels
- Marks declared outputs as Output nodes
- Formats type signatures for display (abbreviates large records)

### Sugiyama Layout (`SugiyamaLayout.scala`)
- Layer assignment using longest path from sources
- Crossing minimization using barycenter heuristic (4 passes)
- Position assignment based on layer and order within layer
- Supports TB (top-to-bottom) and LR (left-to-right) directions
- Configurable node dimensions and spacing via `LayoutConfig`

### LSP Integration
- New `getDagVisualization` endpoint
- `GetDagVisualizationParams` and `GetDagVisualizationResult` types
- Full `DagVisualization` response with nodes, edges, groups, and metadata

### Other Changes
- Added `compileToIR` method to `LangCompiler` trait
- Updated `CachingLangCompiler`, `StdLibCompiler`, `ExampleLibCompiler` with new method
- Updated test mocks with `compileToIR` implementation

## Test plan

- [x] All existing tests pass (168 tests)
- [x] New `DagVizCompilerTest` passes (7 test cases)
- [x] New `SugiyamaLayoutTest` passes (9 test cases)
- [x] Total: 184 tests pass

**Test Coverage:**
- DagVizCompiler: single node, linear pipeline, diamond pattern, literals, guards, record type abbreviation, edge labels
- SugiyamaLayout: single node, linear pipeline, diamond pattern, LR direction, multiple inputs, bounds calculation, empty dag, custom config, crossing minimization

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)