### PR TITLE
feat(viz): add Mermaid, DOT, and ASCII renderers for DAG visualization

### DIFF
--- a/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/ASCIIRenderer.scala
+++ b/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/ASCIIRenderer.scala
@@ -1,0 +1,294 @@
+package io.constellation.lang.viz
+
+import scala.collection.mutable
+
+/** Renders a DagVizIR as ASCII art.
+  *
+  * This renderer produces text-based visualizations suitable for terminal output,
+  * logs, and environments without graphics support.
+  *
+  * The output uses Unicode box-drawing characters for better visual appearance.
+  * If the DAG has been laid out (nodes have positions), the renderer will organize
+  * nodes by layer. Otherwise, it will perform a simple topological sort.
+  */
+object ASCIIRenderer extends DagRenderer {
+
+  private val BoxWidth = 24
+  private val BoxChars = BoxCharacters.Unicode
+
+  case class BoxCharacters(
+      topLeft: Char,
+      topRight: Char,
+      bottomLeft: Char,
+      bottomRight: Char,
+      horizontal: Char,
+      vertical: Char,
+      downArrow: Char,
+      rightArrow: Char,
+      teeDown: Char,
+      teeUp: Char,
+      teeRight: Char,
+      teeLeft: Char,
+      cross: Char
+  )
+
+  object BoxCharacters {
+    val Unicode = BoxCharacters(
+      topLeft = '\u250c',     // ┌
+      topRight = '\u2510',    // ┐
+      bottomLeft = '\u2514',  // └
+      bottomRight = '\u2518', // ┘
+      horizontal = '\u2500',  // ─
+      vertical = '\u2502',    // │
+      downArrow = '\u25bc',   // ▼
+      rightArrow = '\u25b6',  // ▶
+      teeDown = '\u252c',     // ┬
+      teeUp = '\u2534',       // ┴
+      teeRight = '\u251c',    // ├
+      teeLeft = '\u2524',     // ┤
+      cross = '\u253c'        // ┼
+    )
+
+    val ASCII = BoxCharacters(
+      topLeft = '+',
+      topRight = '+',
+      bottomLeft = '+',
+      bottomRight = '+',
+      horizontal = '-',
+      vertical = '|',
+      downArrow = 'v',
+      rightArrow = '>',
+      teeDown = '+',
+      teeUp = '+',
+      teeRight = '+',
+      teeLeft = '+',
+      cross = '+'
+    )
+  }
+
+  def render(dag: DagVizIR): String = {
+    if (dag.nodes.isEmpty) return "(empty DAG)"
+
+    val sb = new StringBuilder
+
+    // Add title if present
+    dag.metadata.title.foreach { title =>
+      sb.append(s"=== $title ===\n\n")
+    }
+
+    // Group nodes by layer (y position) or compute layers
+    val layers = computeLayers(dag)
+
+    // Render each layer
+    layers.zipWithIndex.foreach { case (layerNodes, layerIdx) =>
+      // Render the nodes in this layer
+      renderLayer(sb, layerNodes, dag)
+
+      // Draw connections to next layer (if not last)
+      if (layerIdx < layers.length - 1) {
+        renderConnections(sb, layerNodes, layers(layerIdx + 1), dag)
+      }
+    }
+
+    // Add legend
+    sb.append("\n")
+    renderLegend(sb)
+
+    sb.toString
+  }
+
+  /** Group nodes into layers based on position or topological order */
+  private def computeLayers(dag: DagVizIR): List[List[VizNode]] = {
+    // Check if nodes have positions (from layout)
+    val hasPositions = dag.nodes.exists(_.position.isDefined)
+
+    if (hasPositions) {
+      // Group by Y position (for TB layout) or X position (for LR layout)
+      val isLR   = dag.metadata.layoutDirection == "LR"
+      val groups = dag.nodes.groupBy { node =>
+        node.position.map(p => if (isLR) p.x else p.y).getOrElse(0.0)
+      }
+      groups.toList.sortBy(_._1).map(_._2.sortBy { node =>
+        node.position.map(p => if (isLR) p.y else p.x).getOrElse(0.0)
+      })
+    } else {
+      // Compute layers using topological sort
+      topologicalLayers(dag)
+    }
+  }
+
+  /** Compute layers using Kahn's algorithm (topological sort) */
+  private def topologicalLayers(dag: DagVizIR): List[List[VizNode]] = {
+    val nodeMap   = dag.nodes.map(n => n.id -> n).toMap
+    val outEdges  = dag.edges.groupBy(_.source).map { case (k, v) => k -> v.map(_.target) }
+    val inDegree  = mutable.Map[String, Int]().withDefaultValue(0)
+
+    dag.edges.foreach(e => inDegree(e.target) += 1)
+
+    val layers = mutable.ListBuffer[List[VizNode]]()
+    var current = dag.nodes.filter(n => inDegree(n.id) == 0)
+
+    while (current.nonEmpty) {
+      layers += current
+      val next = mutable.ListBuffer[VizNode]()
+      current.foreach { node =>
+        outEdges.getOrElse(node.id, List.empty).foreach { targetId =>
+          inDegree(targetId) -= 1
+          if (inDegree(targetId) == 0) {
+            nodeMap.get(targetId).foreach(next += _)
+          }
+        }
+      }
+      current = next.toList
+    }
+
+    layers.toList
+  }
+
+  /** Render a layer of nodes */
+  private def renderLayer(sb: StringBuilder, nodes: List[VizNode], dag: DagVizIR): Unit = {
+    val boxes = nodes.map(renderNodeBox)
+    val maxLines = boxes.map(_.length).maxOption.getOrElse(0)
+
+    // Pad boxes to same height
+    val paddedBoxes = boxes.map { box =>
+      val padding = List.fill(maxLines - box.length)(emptyLine)
+      box ++ padding
+    }
+
+    // Render line by line across all boxes
+    for (lineIdx <- 0 until maxLines) {
+      val line = paddedBoxes.map(_(lineIdx)).mkString("  ")
+      sb.append(line).append("\n")
+    }
+  }
+
+  /** Render a single node as a box */
+  private def renderNodeBox(node: VizNode): List[String] = {
+    val lines   = mutable.ListBuffer[String]()
+    val bc      = BoxChars
+    val width   = BoxWidth
+    val inner   = width - 2
+
+    // Kind indicator
+    val kindChar = node.kind match {
+      case NodeKind.Input       => s"${bc.rightArrow} "
+      case NodeKind.Output      => s" ${bc.rightArrow}"
+      case NodeKind.Merge       => "+ "
+      case NodeKind.Conditional => "? "
+      case NodeKind.Guard       => "! "
+      case NodeKind.Literal     => "# "
+      case NodeKind.HigherOrder => "f "
+      case _                    => "  "
+    }
+
+    // Format label
+    val label = truncate(node.label, inner - kindChar.length)
+
+    // Format type (abbreviated)
+    val typeStr = truncate(abbreviateType(node.typeSignature), inner)
+
+    // Build the box
+    lines += s"${bc.topLeft}${bc.horizontal.toString * inner}${bc.topRight}"
+    lines += s"${bc.vertical}${kindChar}${padRight(label, inner - kindChar.length)}${bc.vertical}"
+    if (typeStr.nonEmpty && typeStr != "Unit") {
+      lines += s"${bc.vertical}${padRight(typeStr, inner)}${bc.vertical}"
+    }
+
+    // Execution state if present
+    node.executionState.foreach { state =>
+      val stateStr = state.status match {
+        case ExecutionStatus.Pending   => "[pending]"
+        case ExecutionStatus.Running   => "[RUNNING]"
+        case ExecutionStatus.Completed => "[done]"
+        case ExecutionStatus.Failed    => "[FAILED]"
+      }
+      lines += s"${bc.vertical}${padRight(stateStr, inner)}${bc.vertical}"
+    }
+
+    lines += s"${bc.bottomLeft}${bc.horizontal.toString * inner}${bc.bottomRight}"
+    lines.toList
+  }
+
+  /** Render connections between layers */
+  private def renderConnections(
+      sb: StringBuilder,
+      currentLayer: List[VizNode],
+      nextLayer: List[VizNode],
+      dag: DagVizIR
+  ): Unit = {
+    val boxCenter = BoxWidth / 2
+
+    // Find edges from current layer to next layer
+    val currentIds = currentLayer.map(_.id).toSet
+    val nextIds    = nextLayer.map(_.id).toSet
+    val relevantEdges = dag.edges.filter { e =>
+      currentIds.contains(e.source) && nextIds.contains(e.target)
+    }
+
+    if (relevantEdges.nonEmpty) {
+      // Simple connector line
+      val spacing = "  " // Space between boxes
+      val connectorLine = currentLayer.indices.map { idx =>
+        val nodeId = currentLayer(idx).id
+        val hasEdge = relevantEdges.exists(_.source == nodeId)
+        if (hasEdge) {
+          " " * (boxCenter - 1) + BoxChars.vertical.toString + " " * (BoxWidth - boxCenter)
+        } else {
+          " " * BoxWidth
+        }
+      }.mkString(spacing)
+
+      sb.append(connectorLine).append("\n")
+
+      // Arrow line
+      val arrowLine = currentLayer.indices.map { idx =>
+        val nodeId = currentLayer(idx).id
+        val hasEdge = relevantEdges.exists(_.source == nodeId)
+        if (hasEdge) {
+          " " * (boxCenter - 1) + BoxChars.downArrow.toString + " " * (BoxWidth - boxCenter)
+        } else {
+          " " * BoxWidth
+        }
+      }.mkString(spacing)
+
+      sb.append(arrowLine).append("\n")
+    }
+  }
+
+  /** Render a legend explaining the symbols */
+  private def renderLegend(sb: StringBuilder): Unit = {
+    sb.append("Legend:\n")
+    sb.append(s"  ${BoxChars.rightArrow}  Input    ")
+    sb.append(s"  ${BoxChars.rightArrow} Output   ")
+    sb.append(s"  + Merge    ")
+    sb.append(s"  ? Conditional\n")
+    sb.append(s"  ! Guard    ")
+    sb.append(s"  # Literal  ")
+    sb.append(s"  f Higher-order\n")
+  }
+
+  /** Empty line for padding */
+  private def emptyLine: String = " " * BoxWidth
+
+  /** Truncate text to fit width */
+  private def truncate(text: String, maxLen: Int): String = {
+    if (text.length <= maxLen) text
+    else text.take(maxLen - 3) + "..."
+  }
+
+  /** Pad string to the right */
+  private def padRight(text: String, width: Int): String = {
+    if (text.length >= width) text.take(width)
+    else text + " " * (width - text.length)
+  }
+
+  /** Abbreviate type signatures */
+  private def abbreviateType(typeSignature: String): String = {
+    if (typeSignature.length <= 20) typeSignature
+    else typeSignature.take(17) + "..."
+  }
+
+  def fileExtension: String = "txt"
+  def mimeType: String      = "text/plain"
+}

--- a/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/DOTRenderer.scala
+++ b/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/DOTRenderer.scala
@@ -1,0 +1,217 @@
+package io.constellation.lang.viz
+
+import scala.collection.mutable.ListBuffer
+
+/** Renders a DagVizIR as Graphviz DOT format.
+  *
+  * DOT is the graph description language used by Graphviz. It produces high-quality
+  * vector graphics suitable for academic papers, presentations, and professional
+  * documentation.
+  *
+  * Usage:
+  * {{{
+  * val dot = DOTRenderer.render(dag)
+  * // Then use Graphviz CLI:
+  * // dot -Tpng output.dot -o output.png
+  * // dot -Tsvg output.dot -o output.svg
+  * // dot -Tpdf output.dot -o output.pdf
+  * }}}
+  *
+  * @see https://graphviz.org/doc/info/lang.html
+  */
+object DOTRenderer extends DagRenderer {
+
+  def render(dag: DagVizIR): String = {
+    val sb = new StringBuilder
+
+    // DOT header
+    sb.append("digraph DAG {\n")
+
+    // Graph attributes
+    val rankdir = dag.metadata.layoutDirection match {
+      case "LR" => "LR"
+      case _    => "TB"
+    }
+    sb.append(s"    rankdir=$rankdir;\n")
+    sb.append("    splines=ortho;\n")
+    sb.append("    nodesep=0.8;\n")
+    sb.append("    ranksep=1.0;\n")
+    sb.append("\n")
+
+    // Default node attributes
+    sb.append("    node [\n")
+    sb.append("        fontname=\"Helvetica\"\n")
+    sb.append("        fontsize=12\n")
+    sb.append("        style=filled\n")
+    sb.append("    ];\n")
+    sb.append("\n")
+
+    // Default edge attributes
+    sb.append("    edge [\n")
+    sb.append("        fontname=\"Helvetica\"\n")
+    sb.append("        fontsize=10\n")
+    sb.append("    ];\n")
+    sb.append("\n")
+
+    // Add title as a graph label if present
+    dag.metadata.title.foreach { title =>
+      sb.append(s"    label=${quote(title)};\n")
+      sb.append("    labelloc=t;\n")
+      sb.append("    fontsize=16;\n")
+      sb.append("\n")
+    }
+
+    // Render groups as clusters (subgraphs)
+    dag.groups.foreach { group =>
+      sb.append(s"    subgraph cluster_${sanitizeId(group.id)} {\n")
+      sb.append(s"        label=${quote(group.label)};\n")
+      sb.append("        style=rounded;\n")
+      sb.append("        color=\"#94a3b8\";\n")
+      sb.append("        bgcolor=\"#f8fafc\";\n")
+      group.nodeIds.foreach { nodeId =>
+        sb.append(s"        ${quote(nodeId)};\n")
+      }
+      sb.append("    }\n\n")
+    }
+
+    // Render nodes
+    dag.nodes.foreach { node =>
+      val attrs = nodeAttributes(node)
+      sb.append(s"    ${quote(node.id)} [$attrs];\n")
+    }
+
+    sb.append("\n")
+
+    // Render edges
+    dag.edges.foreach { edge =>
+      val attrs = edgeAttributes(edge)
+      val attrStr = if (attrs.nonEmpty) s" [$attrs]" else ""
+      sb.append(s"    ${quote(edge.source)} -> ${quote(edge.target)}$attrStr;\n")
+    }
+
+    sb.append("}\n")
+    sb.toString
+  }
+
+  /** Generate DOT node attributes */
+  private def nodeAttributes(node: VizNode): String = {
+    val attrs = ListBuffer[String]()
+
+    // Label with name and type
+    val typeAbbrev = abbreviateType(node.typeSignature)
+    val label = if (typeAbbrev.isEmpty || typeAbbrev == "Unit") {
+      node.label
+    } else {
+      s"${node.label}\\n${typeAbbrev}"
+    }
+    attrs += s"label=${quote(label)}"
+
+    // Shape based on node kind
+    val shape = node.kind match {
+      case NodeKind.Input       => "ellipse"
+      case NodeKind.Output      => "doubleoctagon"
+      case NodeKind.Operation   => "box"
+      case NodeKind.Literal     => "note"
+      case NodeKind.Merge       => "circle"
+      case NodeKind.Project     => "parallelogram"
+      case NodeKind.FieldAccess => "box"
+      case NodeKind.Conditional => "diamond"
+      case NodeKind.Guard       => "hexagon"
+      case NodeKind.Branch      => "diamond"
+      case NodeKind.Coalesce    => "ellipse"
+      case NodeKind.HigherOrder => "component"
+      case NodeKind.ListLiteral => "folder"
+      case NodeKind.BooleanOp   => "diamond"
+      case NodeKind.StringInterp => "box"
+    }
+    attrs += s"shape=$shape"
+
+    // Colors based on node kind
+    val (fillColor, borderColor) = node.kind match {
+      case NodeKind.Input       => ("#dcfce7", "#22c55e") // Green
+      case NodeKind.Output      => ("#dbeafe", "#3b82f6") // Blue
+      case NodeKind.Operation   => ("#f3f4f6", "#6b7280") // Gray
+      case NodeKind.Literal     => ("#fef3c7", "#f59e0b") // Amber
+      case NodeKind.Merge       => ("#f3e8ff", "#a855f7") // Purple
+      case NodeKind.Project     => ("#e0e7ff", "#6366f1") // Indigo
+      case NodeKind.FieldAccess => ("#f3f4f6", "#6b7280") // Gray
+      case NodeKind.Conditional => ("#fee2e2", "#ef4444") // Red
+      case NodeKind.Guard       => ("#fce7f3", "#ec4899") // Pink
+      case NodeKind.Branch      => ("#fee2e2", "#ef4444") // Red
+      case NodeKind.Coalesce    => ("#ecfeff", "#06b6d4") // Cyan
+      case NodeKind.HigherOrder => ("#cffafe", "#06b6d4") // Cyan
+      case NodeKind.ListLiteral => ("#fef3c7", "#f59e0b") // Amber
+      case NodeKind.BooleanOp   => ("#fef3c7", "#f59e0b") // Amber
+      case NodeKind.StringInterp => ("#f3f4f6", "#6b7280") // Gray
+    }
+    attrs += s"fillcolor=${quote(fillColor)}"
+    attrs += s"color=${quote(borderColor)}"
+
+    // Execution state styling
+    node.executionState.foreach { state =>
+      state.status match {
+        case ExecutionStatus.Running =>
+          attrs += "penwidth=3"
+          attrs += "color=\"#f59e0b\""
+        case ExecutionStatus.Completed =>
+          attrs += "penwidth=2"
+          attrs += "color=\"#22c55e\""
+        case ExecutionStatus.Failed =>
+          attrs += "penwidth=3"
+          attrs += "color=\"#ef4444\""
+          attrs += "fillcolor=\"#fee2e2\""
+        case ExecutionStatus.Pending => // Default styling
+      }
+    }
+
+    attrs.mkString(", ")
+  }
+
+  /** Generate DOT edge attributes */
+  private def edgeAttributes(edge: VizEdge): String = {
+    val attrs = ListBuffer[String]()
+
+    // Label for parameter name
+    edge.label.foreach { l =>
+      attrs += s"label=${quote(l)}"
+    }
+
+    // Edge style based on kind
+    edge.kind match {
+      case EdgeKind.Data =>
+        attrs += "color=\"#374151\""
+      case EdgeKind.Optional =>
+        attrs += "style=dashed"
+        attrs += "color=\"#9ca3af\""
+      case EdgeKind.Control =>
+        attrs += "style=bold"
+        attrs += "color=\"#3b82f6\""
+        attrs += "penwidth=2"
+    }
+
+    attrs.mkString(", ")
+  }
+
+  /** Abbreviate long type signatures */
+  private def abbreviateType(typeSignature: String): String = {
+    if (typeSignature.length <= 25) typeSignature
+    else typeSignature.take(22) + "..."
+  }
+
+  /** Quote a string for DOT format */
+  private def quote(s: String): String = {
+    val escaped = s
+      .replace("\\", "\\\\")
+      .replace("\"", "\\\"")
+      .replace("\n", "\\n")
+    s"\"$escaped\""
+  }
+
+  /** Sanitize an ID for DOT */
+  private def sanitizeId(id: String): String = {
+    id.replaceAll("[^a-zA-Z0-9_]", "_")
+  }
+
+  def fileExtension: String = "dot"
+  def mimeType: String      = "text/vnd.graphviz"
+}

--- a/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/DagRenderer.scala
+++ b/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/DagRenderer.scala
@@ -1,0 +1,37 @@
+package io.constellation.lang.viz
+
+/** Common interface for DAG renderers.
+  *
+  * Renderers transform a DagVizIR into a string representation suitable for different output formats
+  * (Mermaid, DOT/Graphviz, ASCII art, etc.).
+  */
+trait DagRenderer {
+
+  /** Render the DAG to a string in the target format */
+  def render(dag: DagVizIR): String
+
+  /** File extension for the output format (e.g., "mmd", "dot", "txt") */
+  def fileExtension: String
+
+  /** MIME type for the output format */
+  def mimeType: String
+}
+
+object DagRenderer {
+
+  /** Available renderer formats */
+  val mermaid: DagRenderer = MermaidRenderer
+  val dot: DagRenderer     = DOTRenderer
+  val ascii: DagRenderer   = ASCIIRenderer
+
+  /** Get a renderer by format name */
+  def forFormat(format: String): Option[DagRenderer] = format.toLowerCase match {
+    case "mermaid" | "mmd" => Some(MermaidRenderer)
+    case "dot" | "graphviz" => Some(DOTRenderer)
+    case "ascii" | "text" | "txt" => Some(ASCIIRenderer)
+    case _ => None
+  }
+
+  /** List of all available formats */
+  val availableFormats: List[String] = List("mermaid", "dot", "ascii")
+}

--- a/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/MermaidRenderer.scala
+++ b/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/MermaidRenderer.scala
@@ -1,0 +1,160 @@
+package io.constellation.lang.viz
+
+/** Renders a DagVizIR as Mermaid diagram syntax.
+  *
+  * Mermaid is a markdown-based diagramming tool that renders in GitHub, GitLab,
+  * and many documentation platforms. This is the preferred format for README files
+  * and GitHub issues.
+  *
+  * @see https://mermaid.js.org/
+  */
+object MermaidRenderer extends DagRenderer {
+
+  def render(dag: DagVizIR): String = {
+    if (dag.nodes.isEmpty) return "graph TD\n    %% Empty DAG"
+
+    val sb = new StringBuilder
+
+    // Header with direction
+    val direction = dag.metadata.layoutDirection match {
+      case "LR" => "LR"
+      case _    => "TD"
+    }
+    sb.append(s"graph $direction\n")
+
+    // Add title as a comment if present
+    dag.metadata.title.foreach { title =>
+      sb.append(s"    %% $title\n")
+    }
+
+    // Render nodes with appropriate shapes
+    dag.nodes.foreach { node =>
+      val (open, close) = nodeShape(node.kind)
+      val label         = escapeLabel(formatNodeLabel(node))
+      sb.append(s"    ${sanitizeId(node.id)}$open$label$close\n")
+    }
+
+    sb.append("\n")
+
+    // Render edges
+    dag.edges.foreach { edge =>
+      val arrow = edgeArrow(edge.kind)
+      val label = edge.label.map(l => s"|${escapeLabel(l)}|").getOrElse("")
+      sb.append(s"    ${sanitizeId(edge.source)} $arrow$label ${sanitizeId(edge.target)}\n")
+    }
+
+    // Render groups as subgraphs
+    dag.groups.foreach { group =>
+      sb.append(s"\n    subgraph ${sanitizeId(group.id)}[${escapeLabel(group.label)}]\n")
+      group.nodeIds.foreach { nodeId =>
+        sb.append(s"        ${sanitizeId(nodeId)}\n")
+      }
+      sb.append("    end\n")
+    }
+
+    // Add styling classes for node kinds
+    sb.append("\n")
+    addStyling(sb, dag)
+
+    sb.toString
+  }
+
+  /** Get Mermaid shape delimiters for a node kind */
+  private def nodeShape(kind: NodeKind): (String, String) = kind match {
+    case NodeKind.Input       => ("([", "])")   // Stadium shape (rounded ends)
+    case NodeKind.Output      => ("[[", "]]")   // Subroutine shape
+    case NodeKind.Operation   => ("[", "]")     // Rectangle
+    case NodeKind.Literal     => ("(", ")")     // Rounded rectangle
+    case NodeKind.Merge       => ("((", "))")   // Circle
+    case NodeKind.Project     => ("[/", "/]")   // Parallelogram
+    case NodeKind.FieldAccess => ("[", "]")     // Rectangle
+    case NodeKind.Conditional => ("{", "}")     // Diamond
+    case NodeKind.Guard       => ("{{", "}}")   // Hexagon
+    case NodeKind.Branch      => ("{", "}")     // Diamond
+    case NodeKind.Coalesce    => ("([", "])")   // Stadium
+    case NodeKind.HigherOrder => ("[[", "]]")   // Subroutine
+    case NodeKind.ListLiteral => ("(", ")")     // Rounded rectangle
+    case NodeKind.BooleanOp   => ("{", "}")     // Diamond
+    case NodeKind.StringInterp => ("[", "]")   // Rectangle
+  }
+
+  /** Get Mermaid arrow style for an edge kind */
+  private def edgeArrow(kind: EdgeKind): String = kind match {
+    case EdgeKind.Data     => "-->"    // Solid arrow
+    case EdgeKind.Optional => "-.->"   // Dashed arrow
+    case EdgeKind.Control  => "==>"    // Thick arrow
+  }
+
+  /** Format a node's label for display */
+  private def formatNodeLabel(node: VizNode): String = {
+    val typeAbbrev = abbreviateType(node.typeSignature)
+    if (typeAbbrev.isEmpty || typeAbbrev == "Unit") {
+      node.label
+    } else {
+      s"${node.label}<br/><small>${typeAbbrev}</small>"
+    }
+  }
+
+  /** Abbreviate long type signatures */
+  private def abbreviateType(typeSignature: String): String = {
+    if (typeSignature.length <= 30) typeSignature
+    else typeSignature.take(27) + "..."
+  }
+
+  /** Escape special characters for Mermaid labels */
+  private def escapeLabel(text: String): String = {
+    // Mermaid uses quotes for labels with special chars
+    val escaped = text
+      .replace("\\", "\\\\")
+      .replace("\"", "#quot;")
+      .replace("<", "#lt;")
+      .replace(">", "#gt;")
+      .replace("{", "#123;")
+      .replace("}", "#125;")
+      .replace("[", "#91;")
+      .replace("]", "#93;")
+      .replace("|", "#124;")
+
+    s"\"$escaped\""
+  }
+
+  /** Sanitize node IDs for Mermaid (must be alphanumeric with underscores) */
+  private def sanitizeId(id: String): String = {
+    // Replace non-alphanumeric characters with underscores
+    // Prefix with 'n' if starts with a digit
+    val sanitized = id.replaceAll("[^a-zA-Z0-9_]", "_")
+    if (sanitized.headOption.exists(_.isDigit)) s"n$sanitized"
+    else sanitized
+  }
+
+  /** Add CSS-like styling for node types */
+  private def addStyling(sb: StringBuilder, dag: DagVizIR): Unit = {
+    // Group nodes by kind for styling
+    val nodesByKind = dag.nodes.groupBy(_.kind)
+
+    // Define styles for each kind
+    val kindStyles: Map[NodeKind, String] = Map(
+      NodeKind.Input       -> "fill:#22c55e,stroke:#16a34a,color:#fff",
+      NodeKind.Output      -> "fill:#3b82f6,stroke:#2563eb,color:#fff",
+      NodeKind.Operation   -> "fill:#6b7280,stroke:#4b5563,color:#fff",
+      NodeKind.Literal     -> "fill:#f59e0b,stroke:#d97706,color:#fff",
+      NodeKind.Merge       -> "fill:#a855f7,stroke:#9333ea,color:#fff",
+      NodeKind.Conditional -> "fill:#ef4444,stroke:#dc2626,color:#fff",
+      NodeKind.Guard       -> "fill:#ec4899,stroke:#db2777,color:#fff",
+      NodeKind.HigherOrder -> "fill:#06b6d4,stroke:#0891b2,color:#fff"
+    )
+
+    // Apply styles to nodes
+    kindStyles.foreach { case (kind, style) =>
+      nodesByKind.get(kind).foreach { nodes =>
+        if (nodes.nonEmpty) {
+          val nodeIds = nodes.map(n => sanitizeId(n.id)).mkString(",")
+          sb.append(s"    style $nodeIds $style\n")
+        }
+      }
+    }
+  }
+
+  def fileExtension: String = "mmd"
+  def mimeType: String      = "text/x-mermaid"
+}

--- a/modules/lang-compiler/src/test/scala/io/constellation/lang/viz/ASCIIRendererTest.scala
+++ b/modules/lang-compiler/src/test/scala/io/constellation/lang/viz/ASCIIRendererTest.scala
@@ -1,0 +1,285 @@
+package io.constellation.lang.viz
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class ASCIIRendererTest extends AnyFunSuite with Matchers {
+
+  private def makeNode(
+      id: String,
+      kind: NodeKind = NodeKind.Operation,
+      label: String = "",
+      yPos: Option[Double] = None
+  ): VizNode =
+    VizNode(
+      id,
+      kind,
+      if (label.isEmpty) s"Node$id" else label,
+      "String",
+      yPos.map(y => Position(0, y)),
+      None
+    )
+
+  private def makeEdge(source: String, target: String): VizEdge =
+    VizEdge(s"e-$source-$target", source, target, None, EdgeKind.Data)
+
+  test("render empty dag") {
+    val dag = DagVizIR(nodes = List.empty, edges = List.empty)
+    val result = ASCIIRenderer.render(dag)
+
+    result shouldBe "(empty DAG)"
+  }
+
+  test("render single node") {
+    val dag = DagVizIR(
+      nodes = List(makeNode("a", NodeKind.Input, "data")),
+      edges = List.empty
+    )
+
+    val result = ASCIIRenderer.render(dag)
+
+    // Should have box characters
+    result should include("┌")
+    result should include("┐")
+    result should include("└")
+    result should include("┘")
+    result should include("─")
+    result should include("│")
+    result should include("data")
+  }
+
+  test("render input node with indicator") {
+    val dag = DagVizIR(
+      nodes = List(makeNode("a", NodeKind.Input, "data")),
+      edges = List.empty
+    )
+
+    val result = ASCIIRenderer.render(dag)
+
+    result should include("▶") // Input indicator
+  }
+
+  test("render output node with indicator") {
+    val dag = DagVizIR(
+      nodes = List(makeNode("a", NodeKind.Output, "result")),
+      edges = List.empty
+    )
+
+    val result = ASCIIRenderer.render(dag)
+
+    result should include("▶") // Output indicator (at end)
+  }
+
+  test("render merge node with indicator") {
+    val dag = DagVizIR(
+      nodes = List(makeNode("a", NodeKind.Merge, "join")),
+      edges = List.empty
+    )
+
+    val result = ASCIIRenderer.render(dag)
+
+    result should include("+") // Merge indicator
+  }
+
+  test("render conditional node with indicator") {
+    val dag = DagVizIR(
+      nodes = List(makeNode("a", NodeKind.Conditional, "check")),
+      edges = List.empty
+    )
+
+    val result = ASCIIRenderer.render(dag)
+
+    result should include("?") // Conditional indicator
+  }
+
+  test("render linear pipeline with layers") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNode("a", NodeKind.Input, "input", Some(0)),
+        makeNode("b", NodeKind.Operation, "Process", Some(100)),
+        makeNode("c", NodeKind.Output, "output", Some(200))
+      ),
+      edges = List(
+        makeEdge("a", "b"),
+        makeEdge("b", "c")
+      )
+    )
+
+    val result = ASCIIRenderer.render(dag)
+
+    // Should contain all node labels
+    result should include("input")
+    result should include("Process")
+    result should include("output")
+
+    // Should have connectors
+    result should include("│")
+    result should include("▼")
+  }
+
+  test("render nodes side by side in same layer") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNode("a", NodeKind.Input, "input1", Some(0)),
+        makeNode("b", NodeKind.Input, "input2", Some(0))
+      ),
+      edges = List.empty
+    )
+
+    val result = ASCIIRenderer.render(dag)
+
+    // Both nodes should be in the output
+    result should include("input1")
+    result should include("input2")
+
+    // Should have legend
+    result should include("Legend:")
+  }
+
+  test("render with title") {
+    val dag = DagVizIR(
+      nodes = List(makeNode("a", NodeKind.Input, "data")),
+      edges = List.empty,
+      metadata = VizMetadata(title = Some("My Pipeline"))
+    )
+
+    val result = ASCIIRenderer.render(dag)
+
+    result should include("=== My Pipeline ===")
+  }
+
+  test("truncate long labels") {
+    val dag = DagVizIR(
+      nodes = List(
+        VizNode(
+          "a",
+          NodeKind.Operation,
+          "ThisIsAVeryLongLabelThatShouldBeTruncated",
+          "String",
+          None,
+          None
+        )
+      ),
+      edges = List.empty
+    )
+
+    val result = ASCIIRenderer.render(dag)
+
+    result should include("...")
+  }
+
+  test("render type signature") {
+    val dag = DagVizIR(
+      nodes = List(
+        VizNode("a", NodeKind.Input, "data", "List<Int>", None, None)
+      ),
+      edges = List.empty
+    )
+
+    val result = ASCIIRenderer.render(dag)
+
+    result should include("List<Int>")
+  }
+
+  test("render execution state") {
+    val dag = DagVizIR(
+      nodes = List(
+        VizNode(
+          "a",
+          NodeKind.Operation,
+          "running",
+          "String",
+          None,
+          Some(ExecutionState(ExecutionStatus.Running))
+        )
+      ),
+      edges = List.empty
+    )
+
+    val result = ASCIIRenderer.render(dag)
+
+    result should include("[RUNNING]")
+  }
+
+  test("render completed execution state") {
+    val dag = DagVizIR(
+      nodes = List(
+        VizNode(
+          "a",
+          NodeKind.Operation,
+          "done",
+          "String",
+          None,
+          Some(ExecutionState(ExecutionStatus.Completed))
+        )
+      ),
+      edges = List.empty
+    )
+
+    val result = ASCIIRenderer.render(dag)
+
+    result should include("[done]")
+  }
+
+  test("render failed execution state") {
+    val dag = DagVizIR(
+      nodes = List(
+        VizNode(
+          "a",
+          NodeKind.Operation,
+          "failed",
+          "String",
+          None,
+          Some(ExecutionState(ExecutionStatus.Failed, error = Some("Error!")))
+        )
+      ),
+      edges = List.empty
+    )
+
+    val result = ASCIIRenderer.render(dag)
+
+    result should include("[FAILED]")
+  }
+
+  test("renders legend") {
+    val dag = DagVizIR(
+      nodes = List(makeNode("a", NodeKind.Input)),
+      edges = List.empty
+    )
+
+    val result = ASCIIRenderer.render(dag)
+
+    result should include("Legend:")
+    result should include("Input")
+    result should include("Output")
+    result should include("Merge")
+    result should include("Conditional")
+  }
+
+  test("compute layers from topological sort when no positions") {
+    // Nodes without positions should be organized by dependency order
+    val dag = DagVizIR(
+      nodes = List(
+        VizNode("a", NodeKind.Input, "input", "String", None, None),
+        VizNode("b", NodeKind.Operation, "middle", "String", None, None),
+        VizNode("c", NodeKind.Output, "output", "String", None, None)
+      ),
+      edges = List(
+        makeEdge("a", "b"),
+        makeEdge("b", "c")
+      )
+    )
+
+    val result = ASCIIRenderer.render(dag)
+
+    // All nodes should appear
+    result should include("input")
+    result should include("middle")
+    result should include("output")
+  }
+
+  test("file extension and mime type") {
+    ASCIIRenderer.fileExtension shouldBe "txt"
+    ASCIIRenderer.mimeType shouldBe "text/plain"
+  }
+}

--- a/modules/lang-compiler/src/test/scala/io/constellation/lang/viz/DOTRendererTest.scala
+++ b/modules/lang-compiler/src/test/scala/io/constellation/lang/viz/DOTRendererTest.scala
@@ -1,0 +1,239 @@
+package io.constellation.lang.viz
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class DOTRendererTest extends AnyFunSuite with Matchers {
+
+  private def makeNode(id: String, kind: NodeKind = NodeKind.Operation, label: String = ""): VizNode =
+    VizNode(id, kind, if (label.isEmpty) s"Node$id" else label, "String", None, None)
+
+  private def makeEdge(source: String, target: String, kind: EdgeKind = EdgeKind.Data): VizEdge =
+    VizEdge(s"e-$source-$target", source, target, None, kind)
+
+  test("render valid DOT syntax") {
+    val dag = DagVizIR(
+      nodes = List(makeNode("a", NodeKind.Input, "input")),
+      edges = List.empty
+    )
+
+    val result = DOTRenderer.render(dag)
+
+    result should startWith("digraph DAG {")
+    result should endWith("}\n")
+    result should include("rankdir=")
+  }
+
+  test("render empty dag") {
+    val dag = DagVizIR(nodes = List.empty, edges = List.empty)
+    val result = DOTRenderer.render(dag)
+
+    result should startWith("digraph DAG {")
+    result should endWith("}\n")
+  }
+
+  test("render nodes with shapes") {
+    val nodes = List(
+      makeNode("input", NodeKind.Input, "data"),
+      makeNode("output", NodeKind.Output, "result"),
+      makeNode("op", NodeKind.Operation, "Process"),
+      makeNode("merge", NodeKind.Merge, "join"),
+      makeNode("cond", NodeKind.Conditional, "check")
+    )
+
+    val dag = DagVizIR(nodes = nodes, edges = List.empty)
+    val result = DOTRenderer.render(dag)
+
+    result should include("shape=ellipse")       // Input
+    result should include("shape=doubleoctagon") // Output
+    result should include("shape=box")           // Operation
+    result should include("shape=circle")        // Merge
+    result should include("shape=diamond")       // Conditional
+  }
+
+  test("render node colors") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNode("a", NodeKind.Input),
+        makeNode("b", NodeKind.Output)
+      ),
+      edges = List.empty
+    )
+
+    val result = DOTRenderer.render(dag)
+
+    result should include("fillcolor=")
+    result should include("color=")
+    result should include("#22c55e") // Green for input
+    result should include("#3b82f6") // Blue for output
+  }
+
+  test("render edges") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNode("a", NodeKind.Input),
+        makeNode("b", NodeKind.Output)
+      ),
+      edges = List(makeEdge("a", "b"))
+    )
+
+    val result = DOTRenderer.render(dag)
+
+    result should include("\"a\" -> \"b\"")
+  }
+
+  test("render edge labels") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNode("a", NodeKind.Input),
+        makeNode("b", NodeKind.Operation)
+      ),
+      edges = List(
+        VizEdge("e1", "a", "b", Some("param"), EdgeKind.Data)
+      )
+    )
+
+    val result = DOTRenderer.render(dag)
+
+    result should include("label=\"param\"")
+  }
+
+  test("render different edge styles") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNode("a", NodeKind.Input),
+        makeNode("b", NodeKind.Operation),
+        makeNode("c", NodeKind.Operation),
+        makeNode("d", NodeKind.Output)
+      ),
+      edges = List(
+        VizEdge("e1", "a", "b", None, EdgeKind.Data),
+        VizEdge("e2", "a", "c", None, EdgeKind.Optional),
+        VizEdge("e3", "b", "d", None, EdgeKind.Control)
+      )
+    )
+
+    val result = DOTRenderer.render(dag)
+
+    result should include("style=dashed") // Optional edge
+    result should include("style=bold")   // Control edge
+  }
+
+  test("render with title") {
+    val dag = DagVizIR(
+      nodes = List(makeNode("a", NodeKind.Input)),
+      edges = List.empty,
+      metadata = VizMetadata(title = Some("My Pipeline"))
+    )
+
+    val result = DOTRenderer.render(dag)
+
+    result should include("label=\"My Pipeline\"")
+    result should include("labelloc=t")
+  }
+
+  test("render LR direction") {
+    val dag = DagVizIR(
+      nodes = List(makeNode("a", NodeKind.Input)),
+      edges = List.empty,
+      metadata = VizMetadata(layoutDirection = "LR")
+    )
+
+    val result = DOTRenderer.render(dag)
+
+    result should include("rankdir=LR")
+  }
+
+  test("render groups as clusters") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNode("a", NodeKind.Input),
+        makeNode("b", NodeKind.Operation),
+        makeNode("c", NodeKind.Output)
+      ),
+      edges = List(makeEdge("a", "b"), makeEdge("b", "c")),
+      groups = List(
+        NodeGroup("group1", "Processing", List("b"))
+      )
+    )
+
+    val result = DOTRenderer.render(dag)
+
+    result should include("subgraph cluster_group1")
+    result should include("label=\"Processing\"")
+  }
+
+  test("escape quotes in labels") {
+    val dag = DagVizIR(
+      nodes = List(
+        VizNode("a", NodeKind.Input, "data \"quoted\"", "String", None, None)
+      ),
+      edges = List.empty
+    )
+
+    val result = DOTRenderer.render(dag)
+
+    result should include("\\\"quoted\\\"")
+  }
+
+  test("render execution state styling") {
+    val dag = DagVizIR(
+      nodes = List(
+        VizNode(
+          "a",
+          NodeKind.Operation,
+          "running",
+          "String",
+          None,
+          Some(ExecutionState(ExecutionStatus.Running))
+        ),
+        VizNode(
+          "b",
+          NodeKind.Operation,
+          "failed",
+          "String",
+          None,
+          Some(ExecutionState(ExecutionStatus.Failed, error = Some("Error!")))
+        )
+      ),
+      edges = List.empty
+    )
+
+    val result = DOTRenderer.render(dag)
+
+    result should include("penwidth=3") // Running and Failed have thick borders
+  }
+
+  test("node labels include type signature") {
+    val dag = DagVizIR(
+      nodes = List(
+        VizNode("a", NodeKind.Input, "data", "List<String>", None, None)
+      ),
+      edges = List.empty
+    )
+
+    val result = DOTRenderer.render(dag)
+
+    // DOT uses \\n for newlines within labels
+    result should include("data\\\\nList<String>")
+  }
+
+  test("abbreviate long type signatures") {
+    val longType = "{ field1: String, field2: Int, field3: Boolean, field4: Float }"
+    val dag = DagVizIR(
+      nodes = List(
+        VizNode("a", NodeKind.Input, "data", longType, None, None)
+      ),
+      edges = List.empty
+    )
+
+    val result = DOTRenderer.render(dag)
+
+    result should include("...")
+  }
+
+  test("file extension and mime type") {
+    DOTRenderer.fileExtension shouldBe "dot"
+    DOTRenderer.mimeType shouldBe "text/vnd.graphviz"
+  }
+}

--- a/modules/lang-compiler/src/test/scala/io/constellation/lang/viz/DagRendererTest.scala
+++ b/modules/lang-compiler/src/test/scala/io/constellation/lang/viz/DagRendererTest.scala
@@ -1,0 +1,92 @@
+package io.constellation.lang.viz
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class DagRendererTest extends AnyFunSuite with Matchers {
+
+  test("DagRenderer.forFormat returns correct renderer for mermaid") {
+    DagRenderer.forFormat("mermaid") shouldBe Some(MermaidRenderer)
+    DagRenderer.forFormat("mmd") shouldBe Some(MermaidRenderer)
+    DagRenderer.forFormat("MERMAID") shouldBe Some(MermaidRenderer)
+  }
+
+  test("DagRenderer.forFormat returns correct renderer for dot") {
+    DagRenderer.forFormat("dot") shouldBe Some(DOTRenderer)
+    DagRenderer.forFormat("graphviz") shouldBe Some(DOTRenderer)
+    DagRenderer.forFormat("DOT") shouldBe Some(DOTRenderer)
+  }
+
+  test("DagRenderer.forFormat returns correct renderer for ascii") {
+    DagRenderer.forFormat("ascii") shouldBe Some(ASCIIRenderer)
+    DagRenderer.forFormat("text") shouldBe Some(ASCIIRenderer)
+    DagRenderer.forFormat("txt") shouldBe Some(ASCIIRenderer)
+    DagRenderer.forFormat("ASCII") shouldBe Some(ASCIIRenderer)
+  }
+
+  test("DagRenderer.forFormat returns None for unknown format") {
+    DagRenderer.forFormat("unknown") shouldBe None
+    DagRenderer.forFormat("svg") shouldBe None
+    DagRenderer.forFormat("") shouldBe None
+  }
+
+  test("DagRenderer companion object provides direct access to renderers") {
+    DagRenderer.mermaid shouldBe MermaidRenderer
+    DagRenderer.dot shouldBe DOTRenderer
+    DagRenderer.ascii shouldBe ASCIIRenderer
+  }
+
+  test("availableFormats lists all supported formats") {
+    DagRenderer.availableFormats should contain("mermaid")
+    DagRenderer.availableFormats should contain("dot")
+    DagRenderer.availableFormats should contain("ascii")
+  }
+
+  test("all renderers implement DagRenderer trait") {
+    val renderers: List[DagRenderer] = List(
+      MermaidRenderer,
+      DOTRenderer,
+      ASCIIRenderer
+    )
+
+    renderers.foreach { renderer =>
+      renderer.fileExtension should not be empty
+      renderer.mimeType should not be empty
+
+      // Should be able to render an empty DAG
+      val emptyDag = DagVizIR(List.empty, List.empty)
+      val result = renderer.render(emptyDag)
+      result should not be empty
+    }
+  }
+
+  test("all renderers produce different output") {
+    val dag = DagVizIR(
+      nodes = List(
+        VizNode("a", NodeKind.Input, "input", "String", None, None),
+        VizNode("b", NodeKind.Output, "output", "String", None, None)
+      ),
+      edges = List(
+        VizEdge("e1", "a", "b", None, EdgeKind.Data)
+      )
+    )
+
+    val mermaidOutput = MermaidRenderer.render(dag)
+    val dotOutput = DOTRenderer.render(dag)
+    val asciiOutput = ASCIIRenderer.render(dag)
+
+    // All outputs should be different
+    mermaidOutput should not equal dotOutput
+    dotOutput should not equal asciiOutput
+    asciiOutput should not equal mermaidOutput
+
+    // Mermaid starts with "graph"
+    mermaidOutput should startWith("graph")
+
+    // DOT starts with "digraph"
+    dotOutput should startWith("digraph")
+
+    // ASCII has box characters
+    asciiOutput should include("┌")
+  }
+}

--- a/modules/lang-compiler/src/test/scala/io/constellation/lang/viz/MermaidRendererTest.scala
+++ b/modules/lang-compiler/src/test/scala/io/constellation/lang/viz/MermaidRendererTest.scala
@@ -1,0 +1,217 @@
+package io.constellation.lang.viz
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class MermaidRendererTest extends AnyFunSuite with Matchers {
+
+  private def makeNode(id: String, kind: NodeKind = NodeKind.Operation, label: String = ""): VizNode =
+    VizNode(id, kind, if (label.isEmpty) s"Node$id" else label, "String", None, None)
+
+  private def makeEdge(source: String, target: String, kind: EdgeKind = EdgeKind.Data): VizEdge =
+    VizEdge(s"e-$source-$target", source, target, None, kind)
+
+  test("render empty dag") {
+    val dag = DagVizIR(nodes = List.empty, edges = List.empty)
+    val result = MermaidRenderer.render(dag)
+
+    result should include("graph TD")
+    result should include("Empty DAG")
+  }
+
+  test("render single input node") {
+    val dag = DagVizIR(
+      nodes = List(makeNode("a", NodeKind.Input, "data")),
+      edges = List.empty
+    )
+
+    val result = MermaidRenderer.render(dag)
+
+    result should include("graph TD")
+    result should include("([")  // Stadium shape for input
+    result should include("data")
+  }
+
+  test("render linear pipeline") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNode("a", NodeKind.Input, "input"),
+        makeNode("b", NodeKind.Operation, "Process"),
+        makeNode("c", NodeKind.Output, "output")
+      ),
+      edges = List(
+        makeEdge("a", "b"),
+        makeEdge("b", "c")
+      )
+    )
+
+    val result = MermaidRenderer.render(dag)
+
+    result should include("graph TD")
+    result should include("-->")  // Solid arrows
+    result should include("input")
+    result should include("Process")
+    result should include("output")
+    result should include("[[")  // Output shape
+  }
+
+  test("render different node shapes") {
+    val nodes = List(
+      makeNode("input", NodeKind.Input),
+      makeNode("output", NodeKind.Output),
+      makeNode("op", NodeKind.Operation),
+      makeNode("merge", NodeKind.Merge),
+      makeNode("cond", NodeKind.Conditional),
+      makeNode("guard", NodeKind.Guard),
+      makeNode("literal", NodeKind.Literal)
+    )
+
+    val dag = DagVizIR(nodes = nodes, edges = List.empty)
+    val result = MermaidRenderer.render(dag)
+
+    // Check different shape markers are present
+    result should include("([")   // Input - stadium
+    result should include("[[")   // Output - subroutine
+    result should include("[\"")  // Operation - rectangle (with quote)
+    result should include("((")   // Merge - circle
+    result should include("{")    // Conditional - diamond
+    result should include("{{")   // Guard - hexagon
+    result should include("(\"")  // Literal - rounded
+  }
+
+  test("render different edge kinds") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNode("a", NodeKind.Input),
+        makeNode("b", NodeKind.Operation),
+        makeNode("c", NodeKind.Operation),
+        makeNode("d", NodeKind.Output)
+      ),
+      edges = List(
+        VizEdge("e1", "a", "b", None, EdgeKind.Data),
+        VizEdge("e2", "a", "c", None, EdgeKind.Optional),
+        VizEdge("e3", "b", "d", None, EdgeKind.Control)
+      )
+    )
+
+    val result = MermaidRenderer.render(dag)
+
+    result should include("-->")   // Data edge - solid
+    result should include("-.->")  // Optional edge - dashed
+    result should include("==>")   // Control edge - thick
+  }
+
+  test("render edge labels") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNode("a", NodeKind.Input, "x"),
+        makeNode("b", NodeKind.Input, "y"),
+        makeNode("c", NodeKind.Operation, "Add")
+      ),
+      edges = List(
+        VizEdge("e1", "a", "c", Some("left"), EdgeKind.Data),
+        VizEdge("e2", "b", "c", Some("right"), EdgeKind.Data)
+      )
+    )
+
+    val result = MermaidRenderer.render(dag)
+
+    // Mermaid edge labels are escaped with quotes
+    result should include("|\"left\"|")
+    result should include("|\"right\"|")
+  }
+
+  test("render with title") {
+    val dag = DagVizIR(
+      nodes = List(makeNode("a", NodeKind.Input)),
+      edges = List.empty,
+      metadata = VizMetadata(title = Some("My Pipeline"))
+    )
+
+    val result = MermaidRenderer.render(dag)
+
+    result should include("%% My Pipeline")
+  }
+
+  test("render LR direction") {
+    val dag = DagVizIR(
+      nodes = List(makeNode("a", NodeKind.Input)),
+      edges = List.empty,
+      metadata = VizMetadata(layoutDirection = "LR")
+    )
+
+    val result = MermaidRenderer.render(dag)
+
+    result should include("graph LR")
+  }
+
+  test("render groups as subgraphs") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNode("a", NodeKind.Input),
+        makeNode("b", NodeKind.Operation),
+        makeNode("c", NodeKind.Output)
+      ),
+      edges = List(makeEdge("a", "b"), makeEdge("b", "c")),
+      groups = List(
+        NodeGroup("group1", "Processing", List("b"))
+      )
+    )
+
+    val result = MermaidRenderer.render(dag)
+
+    result should include("subgraph group1")
+    result should include("Processing")
+    result should include("end")
+  }
+
+  test("escape special characters in labels") {
+    val dag = DagVizIR(
+      nodes = List(makeNode("a", NodeKind.Input, "data<String>")),
+      edges = List.empty
+    )
+
+    val result = MermaidRenderer.render(dag)
+
+    // Should escape < and > characters
+    result should include("#lt;")
+    result should include("#gt;")
+  }
+
+  test("sanitize node IDs") {
+    val dag = DagVizIR(
+      nodes = List(
+        VizNode("123-abc", NodeKind.Input, "test", "String", None, None)
+      ),
+      edges = List.empty
+    )
+
+    val result = MermaidRenderer.render(dag)
+
+    // IDs starting with numbers should be prefixed
+    result should include("n123")
+    // Dashes should be replaced with underscores
+    result should include("_abc")
+  }
+
+  test("add styling for node kinds") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNode("a", NodeKind.Input),
+        makeNode("b", NodeKind.Output)
+      ),
+      edges = List.empty
+    )
+
+    val result = MermaidRenderer.render(dag)
+
+    // Should have style directives
+    result should include("style")
+    result should include("fill:")
+  }
+
+  test("file extension and mime type") {
+    MermaidRenderer.fileExtension shouldBe "mmd"
+    MermaidRenderer.mimeType shouldBe "text/x-mermaid"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds three alternative text-based renderers for `DagVizIR` visualization
- Creates `DagRenderer` trait as common interface for all renderers
- Implements `MermaidRenderer` for GitHub/GitLab markdown diagrams
- Implements `DOTRenderer` for Graphviz high-quality output
- Implements `ASCIIRenderer` for terminal/CLI visualization

## Changes

### DagRenderer Trait (`DagRenderer.scala`)
- Common interface: `render(dag)`, `fileExtension`, `mimeType`
- Factory method: `DagRenderer.forFormat(\"mermaid\")` returns appropriate renderer
- Direct access: `DagRenderer.mermaid`, `DagRenderer.dot`, `DagRenderer.ascii`
- Lists available formats via `DagRenderer.availableFormats`

### MermaidRenderer (`MermaidRenderer.scala`)
- Outputs Mermaid.js diagram syntax for markdown
- Different shapes for each NodeKind:
  - Input: Stadium `([...])`
  - Output: Subroutine `[[...]]`
  - Operation: Rectangle `[...]`
  - Merge: Circle `((...))` 
  - Conditional: Diamond `{...}`
  - Guard: Hexagon `{{...}}`
- Edge styles: solid `-->` (Data), dashed `-.->` (Optional), thick `==>` (Control)
- Groups rendered as subgraphs
- Adds CSS-like styling with semantic colors

### DOTRenderer (`DOTRenderer.scala`)
- Outputs Graphviz DOT language
- Use with: `dot -Tpng output.dot -o output.png`
- Node shapes and colors matching Mermaid semantics
- Execution state styling (thick borders for running/failed)
- Groups as cluster subgraphs
- Configurable: rankdir, splines, spacing

### ASCIIRenderer (`ASCIIRenderer.scala`)
- Unicode box-drawing characters for terminal output
- Organizes nodes by layer (from layout positions or topological sort)
- Kind indicators: `▶` (input/output), `+` (merge), `?` (conditional), `!` (guard)
- Shows execution state: `[RUNNING]`, `[done]`, `[FAILED]`
- Includes helpful legend at bottom

## Example Output

**Mermaid:**
```mermaid
graph TD
    a([\"input\"])
    b[\"Process\"]
    c[[\"output\"]]
    
    a --> b
    b --> c
    
    style a fill:#22c55e,stroke:#16a34a,color:#fff
    style c fill:#3b82f6,stroke:#2563eb,color:#fff
```

**ASCII:**
```
┌──────────────────────┐
│ ▶ input              │
│ String               │
└──────────────────────┘
           │
           ▼
┌──────────────────────┐
│   Process            │
│ String               │
└──────────────────────┘
           │
           ▼
┌──────────────────────┐
│   output ▶           │
│ String               │
└──────────────────────┘

Legend:
  ▶  Input     ▶ Output    + Merge    ? Conditional
```

## Test plan

- [x] DagRendererTest: 8 tests for factory and trait behavior
- [x] MermaidRendererTest: 13 tests for all Mermaid features
- [x] DOTRendererTest: 15 tests for all DOT features
- [x] ASCIIRendererTest: 17 tests for all ASCII features
- [x] All existing tests pass (1017 total tests)

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)