### PR TITLE
feat(viz): add SVG renderer for server-side DAG visualization

### DIFF
--- a/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/DagRenderer.scala
+++ b/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/DagRenderer.scala
@@ -23,15 +23,17 @@ object DagRenderer {
   val mermaid: DagRenderer = MermaidRenderer
   val dot: DagRenderer     = DOTRenderer
   val ascii: DagRenderer   = ASCIIRenderer
+  val svg: DagRenderer     = SVGRenderer
 
   /** Get a renderer by format name */
   def forFormat(format: String): Option[DagRenderer] = format.toLowerCase match {
     case "mermaid" | "mmd" => Some(MermaidRenderer)
     case "dot" | "graphviz" => Some(DOTRenderer)
     case "ascii" | "text" | "txt" => Some(ASCIIRenderer)
+    case "svg" => Some(SVGRenderer)
     case _ => None
   }
 
   /** List of all available formats */
-  val availableFormats: List[String] = List("mermaid", "dot", "ascii")
+  val availableFormats: List[String] = List("mermaid", "dot", "ascii", "svg")
 }

--- a/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/SVGRenderer.scala
+++ b/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/SVGRenderer.scala
@@ -1,0 +1,378 @@
+package io.constellation.lang.viz
+
+import scala.collection.mutable.ListBuffer
+
+/** Renders a DagVizIR as SVG markup.
+  *
+  * This renderer produces standalone SVG that can be:
+  * - Embedded directly in HTML
+  * - Saved as .svg files
+  * - Used for server-side rendering
+  *
+  * For VSCode integration, client-side rendering is preferred for better theme integration.
+  * This renderer is useful for export, documentation, and headless rendering.
+  */
+object SVGRenderer extends DagRenderer {
+
+  /** Default configuration for SVG rendering */
+  case class SVGConfig(
+      nodeWidth: Double = 160,
+      nodeHeight: Double = 50,
+      inputHeight: Double = 36,
+      outputHeight: Double = 44,
+      moduleHeight: Double = 60,
+      padding: Double = 40,
+      fontFamily: String = "system-ui, -apple-system, sans-serif",
+      fontSize: Int = 12,
+      background: Option[String] = None // None = transparent
+  )
+
+  /** Node colors by kind */
+  private object Colors {
+    val inputFill    = "#dcfce7"
+    val inputStroke  = "#22c55e"
+    val outputFill   = "#dbeafe"
+    val outputStroke = "#3b82f6"
+    val opFill       = "#f3f4f6"
+    val opStroke     = "#6b7280"
+    val opHeader     = "#6b7280"
+    val literalFill  = "#fef3c7"
+    val literalStroke = "#f59e0b"
+    val mergeFill    = "#f3e8ff"
+    val mergeStroke  = "#a855f7"
+    val guardFill    = "#fef9c3"
+    val guardStroke  = "#eab308"
+    val condFill     = "#fee2e2"
+    val condStroke   = "#ef4444"
+    val hofFill      = "#cffafe"
+    val hofStroke    = "#06b6d4"
+    val edgeColor    = "#64748b"
+    val textColor    = "#1f2937"
+    val textLight    = "#6b7280"
+
+    // Execution state colors
+    val pendingStroke   = "#9ca3af"
+    val runningStroke   = "#3b82f6"
+    val completedStroke = "#22c55e"
+    val failedStroke    = "#ef4444"
+    val failedFill      = "#fef2f2"
+  }
+
+  def render(dag: DagVizIR): String =
+    render(dag, SVGConfig())
+
+  def render(dag: DagVizIR, config: SVGConfig): String = {
+    if (dag.nodes.isEmpty) {
+      return s"""<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100">
+        <text x="100" y="50" text-anchor="middle" fill="${Colors.textLight}" font-family="${config.fontFamily}">(empty DAG)</text>
+      </svg>"""
+    }
+
+    val sb = new StringBuilder
+
+    // Calculate bounds from node positions or use metadata
+    val bounds = dag.metadata.bounds.getOrElse(calculateBounds(dag, config))
+    val width  = bounds.maxX - bounds.minX + config.padding * 2
+    val height = bounds.maxY - bounds.minY + config.padding * 2
+    val viewBox = s"${bounds.minX - config.padding} ${bounds.minY - config.padding} $width $height"
+
+    // SVG header
+    sb.append(s"""<svg xmlns="http://www.w3.org/2000/svg" viewBox="$viewBox" width="$width" height="$height">\n""")
+
+    // Embedded styles
+    sb.append(renderStyles(config))
+
+    // Background if specified
+    config.background.foreach { bg =>
+      sb.append(s"""  <rect x="${bounds.minX - config.padding}" y="${bounds.minY - config.padding}" """)
+      sb.append(s"""width="$width" height="$height" fill="$bg"/>\n""")
+    }
+
+    // Arrow marker definition
+    sb.append(renderDefs())
+
+    // Title if present
+    dag.metadata.title.foreach { title =>
+      sb.append(s"""  <title>$title</title>\n""")
+    }
+
+    // Render edges first (behind nodes)
+    sb.append("  <g class=\"edges\">\n")
+    dag.edges.foreach { edge =>
+      sb.append(renderEdge(edge, dag, config))
+    }
+    sb.append("  </g>\n")
+
+    // Render nodes
+    sb.append("  <g class=\"nodes\">\n")
+    dag.nodes.foreach { node =>
+      sb.append(renderNode(node, config))
+    }
+    sb.append("  </g>\n")
+
+    sb.append("</svg>")
+    sb.toString
+  }
+
+  private def calculateBounds(dag: DagVizIR, config: SVGConfig): Bounds = {
+    val positions = dag.nodes.flatMap(_.position)
+    if (positions.isEmpty) {
+      Bounds(0, 0, 400, 300)
+    } else {
+      val xs = positions.map(_.x)
+      val ys = positions.map(_.y)
+      Bounds(
+        minX = xs.min - config.nodeWidth / 2,
+        minY = ys.min - config.moduleHeight / 2,
+        maxX = xs.max + config.nodeWidth / 2,
+        maxY = ys.max + config.moduleHeight / 2
+      )
+    }
+  }
+
+  private def renderStyles(config: SVGConfig): String = {
+    s"""  <style>
+    .node rect, .node ellipse, .node polygon { stroke-width: 2; }
+    .node text { font-family: ${config.fontFamily}; font-size: ${config.fontSize}px; fill: ${Colors.textColor}; }
+    .node .label { font-weight: 500; }
+    .node .type-sig { font-size: ${config.fontSize - 2}px; fill: ${Colors.textLight}; }
+    .edge path { fill: none; stroke: ${Colors.edgeColor}; stroke-width: 1.5; }
+    .edge.optional path { stroke-dasharray: 5,5; }
+    .edge.control path { stroke-width: 2.5; stroke: ${Colors.outputStroke}; }
+    .edge text { font-size: ${config.fontSize - 3}px; fill: ${Colors.textLight}; }
+    .node.state-running rect, .node.state-running ellipse, .node.state-running polygon { stroke: ${Colors.runningStroke}; stroke-width: 3; }
+    .node.state-completed rect, .node.state-completed ellipse, .node.state-completed polygon { stroke: ${Colors.completedStroke}; }
+    .node.state-failed rect, .node.state-failed ellipse, .node.state-failed polygon { stroke: ${Colors.failedStroke}; fill: ${Colors.failedFill}; }
+    .node.state-pending { opacity: 0.7; }
+  </style>
+"""
+  }
+
+  private def renderDefs(): String = {
+    s"""  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="${Colors.edgeColor}"/>
+    </marker>
+    <marker id="arrowhead-control" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="${Colors.outputStroke}"/>
+    </marker>
+  </defs>
+"""
+  }
+
+  private def renderNode(node: VizNode, config: SVGConfig): String = {
+    val pos = node.position.getOrElse(Position(0, 0))
+    val sb  = new StringBuilder
+
+    // Execution state class
+    val stateClass = node.executionState.map(s => s" state-${s.status.toString.toLowerCase}").getOrElse("")
+
+    // Get dimensions and colors based on node kind
+    val (width, height, fillColor, strokeColor) = node.kind match {
+      case NodeKind.Input       => (config.nodeWidth, config.inputHeight, Colors.inputFill, Colors.inputStroke)
+      case NodeKind.Output      => (config.nodeWidth, config.outputHeight, Colors.outputFill, Colors.outputStroke)
+      case NodeKind.Operation   => (config.nodeWidth, config.moduleHeight, Colors.opFill, Colors.opStroke)
+      case NodeKind.Literal     => (config.nodeWidth, config.nodeHeight, Colors.literalFill, Colors.literalStroke)
+      case NodeKind.Merge       => (config.nodeWidth, config.nodeHeight, Colors.mergeFill, Colors.mergeStroke)
+      case NodeKind.Guard       => (config.nodeWidth, config.nodeHeight, Colors.guardFill, Colors.guardStroke)
+      case NodeKind.Conditional => (config.nodeWidth, config.nodeHeight, Colors.condFill, Colors.condStroke)
+      case NodeKind.Branch      => (config.nodeWidth, config.nodeHeight, Colors.condFill, Colors.condStroke)
+      case NodeKind.HigherOrder => (config.nodeWidth, config.nodeHeight, Colors.hofFill, Colors.hofStroke)
+      case _                    => (config.nodeWidth, config.nodeHeight, Colors.opFill, Colors.opStroke)
+    }
+
+    val x = pos.x - width / 2
+    val y = pos.y - height / 2
+
+    sb.append(s"""    <g class="node$stateClass" data-id="${escapeXml(node.id)}">\n""")
+
+    // Shape based on kind
+    node.kind match {
+      case NodeKind.Input =>
+        // Ellipse for input
+        sb.append(s"""      <ellipse cx="${pos.x}" cy="${pos.y}" rx="${width / 2}" ry="${height / 2}" """)
+        sb.append(s"""fill="$fillColor" stroke="$strokeColor"/>\n""")
+
+      case NodeKind.Output =>
+        // Hexagon for output
+        val points = hexagonPoints(x, y, width, height)
+        sb.append(s"""      <polygon points="$points" fill="$fillColor" stroke="$strokeColor"/>\n""")
+
+      case NodeKind.Operation =>
+        // Rectangle with header bar
+        sb.append(s"""      <rect x="$x" y="$y" width="$width" height="$height" rx="4" ry="4" """)
+        sb.append(s"""fill="$fillColor" stroke="$strokeColor"/>\n""")
+        sb.append(s"""      <rect x="$x" y="$y" width="$width" height="8" rx="4" ry="4" """)
+        sb.append(s"""fill="$strokeColor"/>\n""")
+
+      case NodeKind.Merge =>
+        // Circle for merge
+        val radius = Math.min(width, height) / 2 - 5
+        sb.append(s"""      <circle cx="${pos.x}" cy="${pos.y}" r="$radius" """)
+        sb.append(s"""fill="$fillColor" stroke="$strokeColor"/>\n""")
+
+      case NodeKind.Conditional | NodeKind.Branch =>
+        // Diamond for conditional
+        val points = diamondPoints(pos.x, pos.y, width * 0.7, height)
+        sb.append(s"""      <polygon points="$points" fill="$fillColor" stroke="$strokeColor"/>\n""")
+
+      case _ =>
+        // Default rounded rectangle
+        sb.append(s"""      <rect x="$x" y="$y" width="$width" height="$height" rx="8" ry="8" """)
+        sb.append(s"""fill="$fillColor" stroke="$strokeColor"/>\n""")
+    }
+
+    // Icon based on kind
+    val icon = node.kind match {
+      case NodeKind.Input       => "▶"
+      case NodeKind.Output      => "▶"
+      case NodeKind.Merge       => "⊕"
+      case NodeKind.Literal     => "#"
+      case NodeKind.Guard       => "?"
+      case NodeKind.Conditional => "⑂"
+      case NodeKind.HigherOrder => "ƒ"
+      case _                    => ""
+    }
+
+    if (icon.nonEmpty) {
+      val iconX = if (node.kind == NodeKind.Output) pos.x + width / 2 - 16 else x + 12
+      sb.append(s"""      <text x="$iconX" y="${pos.y + 4}" class="icon">${escapeXml(icon)}</text>\n""")
+    }
+
+    // Label
+    val labelY = node.kind match {
+      case NodeKind.Operation => pos.y
+      case _                  => pos.y + 4
+    }
+    sb.append(s"""      <text x="${pos.x}" y="$labelY" text-anchor="middle" class="label">${escapeXml(truncate(node.label, 18))}</text>\n""")
+
+    // Type signature (abbreviated)
+    if (node.typeSignature.nonEmpty && node.typeSignature != "Unit") {
+      val typeY = labelY + 14
+      val abbrevType = abbreviateType(node.typeSignature)
+      sb.append(s"""      <text x="${pos.x}" y="$typeY" text-anchor="middle" class="type-sig">${escapeXml(abbrevType)}</text>\n""")
+    }
+
+    // Execution state indicator
+    node.executionState.foreach { state =>
+      val stateIcon = state.status match {
+        case ExecutionStatus.Completed => "✓"
+        case ExecutionStatus.Failed    => "✗"
+        case ExecutionStatus.Running   => "⟳"
+        case _                         => ""
+      }
+      if (stateIcon.nonEmpty) {
+        sb.append(s"""      <text x="${x + 10}" y="${y + 14}" class="state-icon">$stateIcon</text>\n""")
+      }
+    }
+
+    sb.append("    </g>\n")
+    sb.toString
+  }
+
+  private def renderEdge(edge: VizEdge, dag: DagVizIR, config: SVGConfig): String = {
+    val sourceNode = dag.nodes.find(_.id == edge.source)
+    val targetNode = dag.nodes.find(_.id == edge.target)
+
+    (sourceNode, targetNode) match {
+      case (Some(src), Some(tgt)) =>
+        val srcPos = src.position.getOrElse(Position(0, 0))
+        val tgtPos = tgt.position.getOrElse(Position(0, 0))
+
+        val sb = new StringBuilder
+
+        val edgeClass = edge.kind match {
+          case EdgeKind.Optional => " optional"
+          case EdgeKind.Control  => " control"
+          case _                 => ""
+        }
+        val marker = if (edge.kind == EdgeKind.Control) "url(#arrowhead-control)" else "url(#arrowhead)"
+
+        sb.append(s"""    <g class="edge$edgeClass" data-source="${edge.source}" data-target="${edge.target}">\n""")
+
+        // Calculate path based on layout direction
+        val isVertical = dag.metadata.layoutDirection == "TB"
+        val (startX, startY, endX, endY) = if (isVertical) {
+          val sy = srcPos.y + getNodeHeight(src.kind, config) / 2
+          val ey = tgtPos.y - getNodeHeight(tgt.kind, config) / 2
+          (srcPos.x, sy, tgtPos.x, ey)
+        } else {
+          val sx = srcPos.x + config.nodeWidth / 2
+          val ex = tgtPos.x - config.nodeWidth / 2
+          (sx, srcPos.y, ex, tgtPos.y)
+        }
+
+        // Bezier curve
+        val (midX, midY) = if (isVertical) {
+          (startX, (startY + endY) / 2)
+        } else {
+          ((startX + endX) / 2, startY)
+        }
+
+        val path = if (isVertical) {
+          s"M $startX $startY C $startX $midY, $endX $midY, $endX $endY"
+        } else {
+          s"M $startX $startY C $midX $startY, $midX $endY, $endX $endY"
+        }
+
+        sb.append(s"""      <path d="$path" marker-end="$marker"/>\n""")
+
+        // Edge label if present
+        edge.label.foreach { label =>
+          val labelX = (startX + endX) / 2
+          val labelY = (startY + endY) / 2 - 5
+          sb.append(s"""      <text x="$labelX" y="$labelY" text-anchor="middle">${escapeXml(label)}</text>\n""")
+        }
+
+        sb.append("    </g>\n")
+        sb.toString
+
+      case _ => ""
+    }
+  }
+
+  private def getNodeHeight(kind: NodeKind, config: SVGConfig): Double = kind match {
+    case NodeKind.Input     => config.inputHeight
+    case NodeKind.Output    => config.outputHeight
+    case NodeKind.Operation => config.moduleHeight
+    case _                  => config.nodeHeight
+  }
+
+  private def hexagonPoints(x: Double, y: Double, width: Double, height: Double): String = {
+    val inset = 12
+    List(
+      (x + inset, y),
+      (x + width - inset, y),
+      (x + width, y + height / 2),
+      (x + width - inset, y + height),
+      (x + inset, y + height),
+      (x, y + height / 2)
+    ).map { case (px, py) => s"$px,$py" }.mkString(" ")
+  }
+
+  private def diamondPoints(cx: Double, cy: Double, width: Double, height: Double): String = {
+    List(
+      (cx, cy - height / 2),
+      (cx + width / 2, cy),
+      (cx, cy + height / 2),
+      (cx - width / 2, cy)
+    ).map { case (px, py) => s"$px,$py" }.mkString(" ")
+  }
+
+  private def truncate(s: String, maxLen: Int): String =
+    if (s.length <= maxLen) s else s.take(maxLen - 1) + "…"
+
+  private def abbreviateType(typeSignature: String): String =
+    if (typeSignature.length <= 20) typeSignature
+    else typeSignature.take(17) + "..."
+
+  private def escapeXml(s: String): String =
+    s.replace("&", "&amp;")
+      .replace("<", "&lt;")
+      .replace(">", "&gt;")
+      .replace("\"", "&quot;")
+      .replace("'", "&apos;")
+
+  def fileExtension: String = "svg"
+  def mimeType: String      = "image/svg+xml"
+}

--- a/modules/lang-compiler/src/test/scala/io/constellation/lang/viz/DagRendererTest.scala
+++ b/modules/lang-compiler/src/test/scala/io/constellation/lang/viz/DagRendererTest.scala
@@ -24,9 +24,14 @@ class DagRendererTest extends AnyFunSuite with Matchers {
     DagRenderer.forFormat("ASCII") shouldBe Some(ASCIIRenderer)
   }
 
+  test("DagRenderer.forFormat returns correct renderer for svg") {
+    DagRenderer.forFormat("svg") shouldBe Some(SVGRenderer)
+    DagRenderer.forFormat("SVG") shouldBe Some(SVGRenderer)
+  }
+
   test("DagRenderer.forFormat returns None for unknown format") {
     DagRenderer.forFormat("unknown") shouldBe None
-    DagRenderer.forFormat("svg") shouldBe None
+    DagRenderer.forFormat("pdf") shouldBe None
     DagRenderer.forFormat("") shouldBe None
   }
 
@@ -34,19 +39,22 @@ class DagRendererTest extends AnyFunSuite with Matchers {
     DagRenderer.mermaid shouldBe MermaidRenderer
     DagRenderer.dot shouldBe DOTRenderer
     DagRenderer.ascii shouldBe ASCIIRenderer
+    DagRenderer.svg shouldBe SVGRenderer
   }
 
   test("availableFormats lists all supported formats") {
     DagRenderer.availableFormats should contain("mermaid")
     DagRenderer.availableFormats should contain("dot")
     DagRenderer.availableFormats should contain("ascii")
+    DagRenderer.availableFormats should contain("svg")
   }
 
   test("all renderers implement DagRenderer trait") {
     val renderers: List[DagRenderer] = List(
       MermaidRenderer,
       DOTRenderer,
-      ASCIIRenderer
+      ASCIIRenderer,
+      SVGRenderer
     )
 
     renderers.foreach { renderer =>
@@ -74,11 +82,15 @@ class DagRendererTest extends AnyFunSuite with Matchers {
     val mermaidOutput = MermaidRenderer.render(dag)
     val dotOutput = DOTRenderer.render(dag)
     val asciiOutput = ASCIIRenderer.render(dag)
+    val svgOutput = SVGRenderer.render(dag)
 
     // All outputs should be different
     mermaidOutput should not equal dotOutput
     dotOutput should not equal asciiOutput
     asciiOutput should not equal mermaidOutput
+    svgOutput should not equal mermaidOutput
+    svgOutput should not equal dotOutput
+    svgOutput should not equal asciiOutput
 
     // Mermaid starts with "graph"
     mermaidOutput should startWith("graph")
@@ -88,5 +100,8 @@ class DagRendererTest extends AnyFunSuite with Matchers {
 
     // ASCII has box characters
     asciiOutput should include("┌")
+
+    // SVG starts with "<svg"
+    svgOutput should startWith("<svg")
   }
 }

--- a/modules/lang-compiler/src/test/scala/io/constellation/lang/viz/SVGRendererTest.scala
+++ b/modules/lang-compiler/src/test/scala/io/constellation/lang/viz/SVGRendererTest.scala
@@ -1,0 +1,396 @@
+package io.constellation.lang.viz
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class SVGRendererTest extends AnyFunSuite with Matchers {
+
+  private def makeNode(id: String, kind: NodeKind = NodeKind.Operation, label: String = ""): VizNode =
+    VizNode(id, kind, if (label.isEmpty) s"Node$id" else label, "String", None, None)
+
+  private def makeNodeWithPosition(id: String, kind: NodeKind, label: String, x: Double, y: Double): VizNode =
+    VizNode(id, kind, label, "String", Some(Position(x, y)), None)
+
+  private def makeEdge(source: String, target: String, kind: EdgeKind = EdgeKind.Data): VizEdge =
+    VizEdge(s"e-$source-$target", source, target, None, kind)
+
+  test("render valid SVG structure") {
+    val dag = DagVizIR(
+      nodes = List(makeNode("a", NodeKind.Input, "input")),
+      edges = List.empty
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    result should startWith("<svg xmlns=\"http://www.w3.org/2000/svg\"")
+    result should include("viewBox=")
+    result should endWith("</svg>")
+  }
+
+  test("render empty dag") {
+    val dag = DagVizIR(nodes = List.empty, edges = List.empty)
+    val result = SVGRenderer.render(dag)
+
+    result should include("<svg")
+    result should include("(empty DAG)")
+  }
+
+  test("render nodes with positions") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNodeWithPosition("a", NodeKind.Input, "data", 100, 50),
+        makeNodeWithPosition("b", NodeKind.Output, "result", 100, 150)
+      ),
+      edges = List(makeEdge("a", "b"))
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    result should include("<g class=\"nodes\">")
+    result should include("data-id=\"a\"")
+    result should include("data-id=\"b\"")
+  }
+
+  test("render input node as ellipse") {
+    val dag = DagVizIR(
+      nodes = List(makeNodeWithPosition("a", NodeKind.Input, "input", 100, 100)),
+      edges = List.empty
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    result should include("<ellipse")
+    result should include("cx=\"100.0\"")
+    result should include("cy=\"100.0\"")
+  }
+
+  test("render output node as hexagon") {
+    val dag = DagVizIR(
+      nodes = List(makeNodeWithPosition("a", NodeKind.Output, "output", 100, 100)),
+      edges = List.empty
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    result should include("<polygon")
+    result should include("points=")
+  }
+
+  test("render operation node as rectangle with header") {
+    val dag = DagVizIR(
+      nodes = List(makeNodeWithPosition("a", NodeKind.Operation, "Process", 100, 100)),
+      edges = List.empty
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    // Operation has two rects - main body and header bar
+    result should include("<rect")
+    result should include("rx=\"4\"")
+  }
+
+  test("render merge node as circle") {
+    val dag = DagVizIR(
+      nodes = List(makeNodeWithPosition("a", NodeKind.Merge, "join", 100, 100)),
+      edges = List.empty
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    result should include("<circle")
+    result should include("cx=\"100.0\"")
+    result should include("cy=\"100.0\"")
+  }
+
+  test("render conditional node as diamond") {
+    val dag = DagVizIR(
+      nodes = List(makeNodeWithPosition("a", NodeKind.Conditional, "check", 100, 100)),
+      edges = List.empty
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    result should include("<polygon")
+    // Diamond shape has 4 points
+    result should include("points=")
+  }
+
+  test("render edges with paths") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNodeWithPosition("a", NodeKind.Input, "x", 100, 50),
+        makeNodeWithPosition("b", NodeKind.Output, "y", 100, 150)
+      ),
+      edges = List(makeEdge("a", "b"))
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    result should include("<g class=\"edges\">")
+    result should include("<path")
+    result should include("marker-end=")
+    result should include("data-source=\"a\"")
+    result should include("data-target=\"b\"")
+  }
+
+  test("render optional edge with dashed style") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNodeWithPosition("a", NodeKind.Input, "x", 100, 50),
+        makeNodeWithPosition("b", NodeKind.Operation, "op", 100, 150)
+      ),
+      edges = List(VizEdge("e1", "a", "b", None, EdgeKind.Optional))
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    result should include("class=\"edge optional\"")
+  }
+
+  test("render control edge with control style") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNodeWithPosition("a", NodeKind.Input, "x", 100, 50),
+        makeNodeWithPosition("b", NodeKind.Output, "y", 100, 150)
+      ),
+      edges = List(VizEdge("e1", "a", "b", None, EdgeKind.Control))
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    result should include("class=\"edge control\"")
+    result should include("url(#arrowhead-control)")
+  }
+
+  test("render edge labels") {
+    val dag = DagVizIR(
+      nodes = List(
+        makeNodeWithPosition("a", NodeKind.Input, "x", 100, 50),
+        makeNodeWithPosition("b", NodeKind.Operation, "Add", 100, 150)
+      ),
+      edges = List(VizEdge("e1", "a", "b", Some("param"), EdgeKind.Data))
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    result should include("param")
+    result should include("text-anchor=\"middle\"")
+  }
+
+  test("render with title") {
+    val dag = DagVizIR(
+      nodes = List(makeNode("a", NodeKind.Input)),
+      edges = List.empty,
+      metadata = VizMetadata(title = Some("My Pipeline"))
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    result should include("<title>My Pipeline</title>")
+  }
+
+  test("render execution state - running") {
+    val dag = DagVizIR(
+      nodes = List(
+        VizNode(
+          "a",
+          NodeKind.Operation,
+          "running",
+          "String",
+          Some(Position(100, 100)),
+          Some(ExecutionState(ExecutionStatus.Running))
+        )
+      ),
+      edges = List.empty
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    result should include("state-running")
+  }
+
+  test("render execution state - completed") {
+    val dag = DagVizIR(
+      nodes = List(
+        VizNode(
+          "a",
+          NodeKind.Operation,
+          "done",
+          "String",
+          Some(Position(100, 100)),
+          Some(ExecutionState(ExecutionStatus.Completed))
+        )
+      ),
+      edges = List.empty
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    result should include("state-completed")
+  }
+
+  test("render execution state - failed") {
+    val dag = DagVizIR(
+      nodes = List(
+        VizNode(
+          "a",
+          NodeKind.Operation,
+          "failed",
+          "String",
+          Some(Position(100, 100)),
+          Some(ExecutionState(ExecutionStatus.Failed, error = Some("Error!")))
+        )
+      ),
+      edges = List.empty
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    result should include("state-failed")
+  }
+
+  test("render type signature") {
+    val dag = DagVizIR(
+      nodes = List(
+        VizNode("a", NodeKind.Input, "data", "List<String>", Some(Position(100, 100)), None)
+      ),
+      edges = List.empty
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    result should include("List&lt;String&gt;")  // XML escaped
+    result should include("class=\"type-sig\"")
+  }
+
+  test("abbreviate long type signatures") {
+    val longType = "{ field1: String, field2: Int, field3: Boolean, field4: Float }"
+    val dag = DagVizIR(
+      nodes = List(
+        VizNode("a", NodeKind.Input, "data", longType, Some(Position(100, 100)), None)
+      ),
+      edges = List.empty
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    result should include("...")
+  }
+
+  test("escape XML characters in labels") {
+    val dag = DagVizIR(
+      nodes = List(
+        VizNode("a", NodeKind.Input, "data<T>", "String", Some(Position(100, 100)), None)
+      ),
+      edges = List.empty
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    result should include("data&lt;T&gt;")
+    result should not include "data<T>"
+  }
+
+  test("escape XML characters in node IDs") {
+    val dag = DagVizIR(
+      nodes = List(
+        VizNode("a&b", NodeKind.Input, "test", "String", Some(Position(100, 100)), None)
+      ),
+      edges = List.empty
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    result should include("data-id=\"a&amp;b\"")
+  }
+
+  test("render with custom config") {
+    val dag = DagVizIR(
+      nodes = List(makeNodeWithPosition("a", NodeKind.Input, "input", 100, 100)),
+      edges = List.empty
+    )
+
+    val config = SVGRenderer.SVGConfig(
+      nodeWidth = 200,
+      fontSize = 14,
+      background = Some("#ffffff")
+    )
+
+    val result = SVGRenderer.render(dag, config)
+
+    result should include("font-size: 14px")
+    result should include("fill=\"#ffffff\"")
+  }
+
+  test("include embedded styles") {
+    val dag = DagVizIR(
+      nodes = List(makeNode("a", NodeKind.Input)),
+      edges = List.empty
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    result should include("<style>")
+    result should include(".node")
+    result should include(".edge")
+    result should include("</style>")
+  }
+
+  test("include arrow marker definitions") {
+    val dag = DagVizIR(
+      nodes = List(makeNode("a", NodeKind.Input)),
+      edges = List.empty
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    result should include("<defs>")
+    result should include("<marker id=\"arrowhead\"")
+    result should include("<marker id=\"arrowhead-control\"")
+    result should include("</defs>")
+  }
+
+  test("render different node kinds with correct colors") {
+    val nodes = List(
+      makeNodeWithPosition("input", NodeKind.Input, "in", 100, 50),
+      makeNodeWithPosition("output", NodeKind.Output, "out", 100, 100),
+      makeNodeWithPosition("op", NodeKind.Operation, "proc", 100, 150),
+      makeNodeWithPosition("lit", NodeKind.Literal, "42", 100, 200),
+      makeNodeWithPosition("merge", NodeKind.Merge, "join", 100, 250),
+      makeNodeWithPosition("guard", NodeKind.Guard, "check", 100, 300),
+      makeNodeWithPosition("hof", NodeKind.HigherOrder, "map", 100, 350)
+    )
+
+    val dag = DagVizIR(nodes = nodes, edges = List.empty)
+    val result = SVGRenderer.render(dag)
+
+    // Check that different colors are present
+    result should include("#dcfce7")  // Input fill (green)
+    result should include("#dbeafe")  // Output fill (blue)
+    result should include("#f3f4f6")  // Operation fill (gray)
+    result should include("#fef3c7")  // Literal fill (amber)
+    result should include("#f3e8ff")  // Merge fill (purple)
+    result should include("#fef9c3")  // Guard fill (yellow)
+    result should include("#cffafe")  // HigherOrder fill (cyan)
+  }
+
+  test("use metadata bounds if provided") {
+    val dag = DagVizIR(
+      nodes = List(makeNodeWithPosition("a", NodeKind.Input, "input", 100, 100)),
+      edges = List.empty,
+      metadata = VizMetadata(bounds = Some(Bounds(0, 0, 500, 400)))
+    )
+
+    val result = SVGRenderer.render(dag)
+
+    // Bounds affect the viewBox
+    result should include("viewBox=")
+    result should include("width=\"580.0\"")  // 500 - 0 + 40*2 padding
+    result should include("height=\"480.0\"") // 400 - 0 + 40*2 padding
+  }
+
+  test("file extension and mime type") {
+    SVGRenderer.fileExtension shouldBe "svg"
+    SVGRenderer.mimeType shouldBe "image/svg+xml"
+  }
+}


### PR DESCRIPTION
## Summary

- Add `SVGRenderer.scala` that renders `DagVizIR` to standalone SVG markup
- Update `DagRenderer.scala` to include SVG in the factory methods
- Add comprehensive tests for SVGRenderer (26 tests)
- Update DagRendererTest to include SVG format

## Details

This PR adds server-side SVG rendering for DAG visualization, complementing the existing Mermaid, DOT, and ASCII renderers from #127.

### SVGRenderer Features

- **All node kinds** with distinct shapes:
  - Input: ellipse
  - Output: hexagon
  - Operation: rectangle with header bar
  - Merge: circle
  - Conditional/Branch: diamond
  - Guard/Literal/HigherOrder: rounded rectangles

- **Edge styling**:
  - Data flow: solid lines
  - Optional: dashed lines
  - Control: thick lines

- **Execution state visualization**:
  - Pending: reduced opacity
  - Running: blue stroke, thick border
  - Completed: green stroke
  - Failed: red stroke, light red fill

- **Configurable** via `SVGConfig` case class:
  - Node dimensions
  - Font family and size
  - Padding
  - Optional background color

### Use Cases

- Export functionality
- Documentation generation
- Headless/server-side rendering
- PDF generation pipelines

## Test plan

- [x] All 26 SVGRendererTest tests pass
- [x] All 9 DagRendererTest tests pass (including SVG)
- [x] Full test suite passes (1000+ tests)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)