### PR TITLE
feat(compiler): add IR generation and DAG compilation for module call options

### DIFF
--- a/modules/lang-compiler/src/main/scala/io/constellation/lang/optimizer/CommonSubexpressionElimination.scala
+++ b/modules/lang-compiler/src/main/scala/io/constellation/lang/optimizer/CommonSubexpressionElimination.scala
@@ -67,7 +67,7 @@ object CommonSubexpressionElimination extends OptimizationPass {
     case IRNode.LiteralNode(_, _, _, _) => ""
 
     // Module calls are identified by module name and input mapping
-    case IRNode.ModuleCall(_, moduleName, languageName, inputs, outputType, _) =>
+    case IRNode.ModuleCall(_, moduleName, languageName, inputs, outputType, _, _) =>
       val inputSig = inputs.toSeq.sortBy(_._1).map { case (k, v) => s"$k=$v" }.mkString(",")
       s"call:$moduleName:$languageName:$inputSig:${outputType.prettyPrint}"
 

--- a/modules/lang-compiler/src/main/scala/io/constellation/lang/optimizer/ConstantFolding.scala
+++ b/modules/lang-compiler/src/main/scala/io/constellation/lang/optimizer/ConstantFolding.scala
@@ -62,7 +62,7 @@ object ConstantFolding extends OptimizationPass {
       Some(FoldedValue(value, outputType))
 
     // Module calls can be folded if all inputs are constant and operation is foldable
-    case IRNode.ModuleCall(_, moduleName, _, inputs, outputType, _) =>
+    case IRNode.ModuleCall(_, moduleName, _, inputs, outputType, _, _) =>
       foldModuleCall(moduleName, inputs, folded, outputType)
 
     // AND with constant operands

--- a/modules/lang-compiler/src/main/scala/io/constellation/lang/semantic/TypeChecker.scala
+++ b/modules/lang-compiler/src/main/scala/io/constellation/lang/semantic/TypeChecker.scala
@@ -68,6 +68,8 @@ object TypedExpression {
       name: String,
       signature: FunctionSignature,
       args: List[TypedExpression],
+      options: ModuleCallOptions,
+      typedFallback: Option[TypedExpression],  // Typed fallback expression (if options.fallback is set)
       span: Span
   ) extends TypedExpression {
     def semanticType: SemanticType = signature.returns
@@ -465,7 +467,7 @@ object TypeChecker {
                   }
               }
             }.map { typedArgs =>
-              TypedExpression.FunctionCall(name.fullName, sig, typedArgs, span)
+              TypedExpression.FunctionCall(name.fullName, sig, typedArgs, ModuleCallOptions.empty, None, span)
             }
           }
         case Left(error) =>
@@ -902,7 +904,7 @@ object TypeChecker {
         Some(span)
       ) match {
         case Right(sig) =>
-          val funcCall = TypedExpression.FunctionCall(funcName, sig, List(left, right), span)
+          val funcCall = TypedExpression.FunctionCall(funcName, sig, List(left, right), ModuleCallOptions.empty, None, span)
 
           // For NotEq, wrap in not()
           if op == CompareOp.NotEq then {
@@ -912,7 +914,7 @@ object TypeChecker {
               Some(span)
             ) match {
               case Right(notSig) =>
-                TypedExpression.FunctionCall("not", notSig, List(funcCall), span).validNel
+                TypedExpression.FunctionCall("not", notSig, List(funcCall), ModuleCallOptions.empty, None, span).validNel
               case Left(err) =>
                 err.invalidNel
             }
@@ -990,7 +992,7 @@ object TypeChecker {
       Some(span)
     ) match {
       case Right(sig) =>
-        TypedExpression.FunctionCall(funcName, sig, List(left, right), span).validNel
+        TypedExpression.FunctionCall(funcName, sig, List(left, right), ModuleCallOptions.empty, None, span).validNel
       case Left(err) =>
         err.invalidNel
     }

--- a/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/DagVizCompiler.scala
+++ b/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/DagVizCompiler.scala
@@ -77,7 +77,7 @@ object DagVizCompiler:
           typeSignature = formatType(outputType)
         )
 
-      case IRNode.ModuleCall(_, moduleName, languageName, inputs, outputType, _) =>
+      case IRNode.ModuleCall(_, moduleName, languageName, inputs, outputType, _, _) =>
         VizNode(
           id = id.toString,
           kind = NodeKind.Operation,
@@ -209,7 +209,7 @@ object DagVizCompiler:
   private def getNodeOutputType(node: IRNode): SemanticType =
     node match {
       case IRNode.Input(_, _, outputType, _)                   => outputType
-      case IRNode.ModuleCall(_, _, _, _, outputType, _)        => outputType
+      case IRNode.ModuleCall(_, _, _, _, outputType, _, _)      => outputType
       case IRNode.MergeNode(_, _, _, outputType, _)            => outputType
       case IRNode.ProjectNode(_, _, _, outputType, _)          => outputType
       case IRNode.FieldAccessNode(_, _, _, outputType, _)      => outputType
@@ -238,7 +238,7 @@ object DagVizCompiler:
         case IRNode.Input(_, _, _, _) =>
           List.empty
 
-        case IRNode.ModuleCall(_, _, _, inputs, _, _) =>
+        case IRNode.ModuleCall(_, _, _, inputs, _, _, _) =>
           inputs.map { case (paramName, sourceId) =>
             VizEdge(
               id = nextEdgeId(),

--- a/modules/lang-compiler/src/test/scala/io/constellation/lang/optimizer/CommonSubexpressionEliminationTest.scala
+++ b/modules/lang-compiler/src/test/scala/io/constellation/lang/optimizer/CommonSubexpressionEliminationTest.scala
@@ -1,6 +1,6 @@
 package io.constellation.lang.optimizer
 
-import io.constellation.lang.compiler.{IRNode, IRProgram}
+import io.constellation.lang.compiler.{IRModuleCallOptions, IRNode, IRProgram}
 import io.constellation.lang.semantic.SemanticType
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -23,6 +23,7 @@ class CommonSubexpressionEliminationTest extends AnyFlatSpec with Matchers {
           "add",
           Map("a" -> uuid("x"), "b" -> uuid("y")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         ),
         uuid("add2") -> IRNode.ModuleCall(
@@ -31,6 +32,7 @@ class CommonSubexpressionEliminationTest extends AnyFlatSpec with Matchers {
           "add",
           Map("a" -> uuid("x"), "b" -> uuid("y")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         ),
         uuid("result") -> IRNode.ModuleCall(
@@ -39,6 +41,7 @@ class CommonSubexpressionEliminationTest extends AnyFlatSpec with Matchers {
           "add",
           Map("a" -> uuid("add1"), "b" -> uuid("add2")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),
@@ -57,7 +60,7 @@ class CommonSubexpressionEliminationTest extends AnyFlatSpec with Matchers {
 
     // One of add1 or add2 should be removed
     val addNodes = optimized.nodes.values.collect {
-      case n @ IRNode.ModuleCall(_, "stdlib.math.add", "add", inputs, _, _)
+      case n @ IRNode.ModuleCall(_, "stdlib.math.add", "add", inputs, _, _, _)
           if inputs == Map("a" -> uuid("x"), "b" -> uuid("y")) =>
         n
     }.toList
@@ -79,6 +82,7 @@ class CommonSubexpressionEliminationTest extends AnyFlatSpec with Matchers {
           "add",
           Map("a" -> uuid("x"), "b" -> uuid("y")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         ),
         uuid("mul") -> IRNode.ModuleCall(
@@ -87,6 +91,7 @@ class CommonSubexpressionEliminationTest extends AnyFlatSpec with Matchers {
           "multiply",
           Map("a" -> uuid("x"), "b" -> uuid("y")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),
@@ -166,6 +171,7 @@ class CommonSubexpressionEliminationTest extends AnyFlatSpec with Matchers {
           "add",
           Map("a" -> uuid("field1"), "b" -> uuid("field2")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),
@@ -241,6 +247,7 @@ class CommonSubexpressionEliminationTest extends AnyFlatSpec with Matchers {
           "add",
           Map("a" -> uuid("x"), "b" -> uuid("y")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         ),
         uuid("add2") -> IRNode.ModuleCall(
@@ -249,6 +256,7 @@ class CommonSubexpressionEliminationTest extends AnyFlatSpec with Matchers {
           "add",
           Map("a" -> uuid("x"), "b" -> uuid("y")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         ),
         uuid("mul") -> IRNode.ModuleCall(
@@ -257,6 +265,7 @@ class CommonSubexpressionEliminationTest extends AnyFlatSpec with Matchers {
           "multiply",
           Map("a" -> uuid("add1"), "b" -> uuid("add2")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),

--- a/modules/lang-compiler/src/test/scala/io/constellation/lang/optimizer/ConstantFoldingTest.scala
+++ b/modules/lang-compiler/src/test/scala/io/constellation/lang/optimizer/ConstantFoldingTest.scala
@@ -1,6 +1,6 @@
 package io.constellation.lang.optimizer
 
-import io.constellation.lang.compiler.{IRNode, IRProgram}
+import io.constellation.lang.compiler.{IRModuleCallOptions, IRNode, IRProgram}
 import io.constellation.lang.semantic.SemanticType
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -22,6 +22,7 @@ class ConstantFoldingTest extends AnyFlatSpec with Matchers {
           "add",
           Map("a" -> uuid("a"), "b" -> uuid("b")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),
@@ -50,6 +51,7 @@ class ConstantFoldingTest extends AnyFlatSpec with Matchers {
           "subtract",
           Map("a" -> uuid("a"), "b" -> uuid("b")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),
@@ -77,6 +79,7 @@ class ConstantFoldingTest extends AnyFlatSpec with Matchers {
           "multiply",
           Map("a" -> uuid("a"), "b" -> uuid("b")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),
@@ -104,6 +107,7 @@ class ConstantFoldingTest extends AnyFlatSpec with Matchers {
           "divide",
           Map("a" -> uuid("a"), "b" -> uuid("b")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),
@@ -131,6 +135,7 @@ class ConstantFoldingTest extends AnyFlatSpec with Matchers {
           "divide",
           Map("a" -> uuid("a"), "b" -> uuid("b")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),
@@ -215,6 +220,7 @@ class ConstantFoldingTest extends AnyFlatSpec with Matchers {
           "concat",
           Map("a" -> uuid("a"), "b" -> uuid("b")),
           SemanticType.SString,
+          IRModuleCallOptions.empty,
           None
         )
       ),
@@ -322,6 +328,7 @@ class ConstantFoldingTest extends AnyFlatSpec with Matchers {
           "add",
           Map("a" -> uuid("input"), "b" -> uuid("literal")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),
@@ -349,6 +356,7 @@ class ConstantFoldingTest extends AnyFlatSpec with Matchers {
           "add",
           Map("a" -> uuid("a"), "b" -> uuid("b")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         ),
         uuid("mul") -> IRNode.ModuleCall(
@@ -357,6 +365,7 @@ class ConstantFoldingTest extends AnyFlatSpec with Matchers {
           "multiply",
           Map("a" -> uuid("add"), "b" -> uuid("c")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),

--- a/modules/lang-compiler/src/test/scala/io/constellation/lang/optimizer/DeadCodeEliminationTest.scala
+++ b/modules/lang-compiler/src/test/scala/io/constellation/lang/optimizer/DeadCodeEliminationTest.scala
@@ -1,6 +1,6 @@
 package io.constellation.lang.optimizer
 
-import io.constellation.lang.compiler.{IRNode, IRProgram}
+import io.constellation.lang.compiler.{IRModuleCallOptions, IRNode, IRProgram}
 import io.constellation.lang.semantic.SemanticType
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -24,6 +24,7 @@ class DeadCodeEliminationTest extends AnyFlatSpec with Matchers {
           "add",
           Map("a" -> uuid("input"), "b" -> uuid("literal1")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         ),
         uuid("used") -> IRNode.ModuleCall(
@@ -32,6 +33,7 @@ class DeadCodeEliminationTest extends AnyFlatSpec with Matchers {
           "multiply",
           Map("a" -> uuid("input"), "b" -> uuid("literal2")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),
@@ -67,6 +69,7 @@ class DeadCodeEliminationTest extends AnyFlatSpec with Matchers {
           "add",
           Map("a" -> uuid("input"), "b" -> uuid("literal")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),
@@ -110,6 +113,7 @@ class DeadCodeEliminationTest extends AnyFlatSpec with Matchers {
           "add",
           Map("a" -> uuid("input"), "b" -> uuid("input")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),
@@ -136,6 +140,7 @@ class DeadCodeEliminationTest extends AnyFlatSpec with Matchers {
           "add",
           Map("a" -> uuid("input"), "b" -> uuid("a")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         ),
         uuid("c") -> IRNode.ModuleCall(
@@ -144,6 +149,7 @@ class DeadCodeEliminationTest extends AnyFlatSpec with Matchers {
           "multiply",
           Map("a" -> uuid("b"), "b" -> uuid("a")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         ),
         uuid("d") -> IRNode.LiteralNode(uuid("d"), 42, SemanticType.SInt, None)

--- a/modules/lang-compiler/src/test/scala/io/constellation/lang/optimizer/IROptimizerTest.scala
+++ b/modules/lang-compiler/src/test/scala/io/constellation/lang/optimizer/IROptimizerTest.scala
@@ -1,6 +1,6 @@
 package io.constellation.lang.optimizer
 
-import io.constellation.lang.compiler.{IRNode, IRProgram}
+import io.constellation.lang.compiler.{IRModuleCallOptions, IRNode, IRProgram}
 import io.constellation.lang.semantic.SemanticType
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -25,6 +25,7 @@ class IROptimizerTest extends AnyFlatSpec with Matchers {
           "add",
           Map("a" -> uuid("a"), "b" -> uuid("b")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         ),
         // Dead code
@@ -36,6 +37,7 @@ class IROptimizerTest extends AnyFlatSpec with Matchers {
           "add",
           Map("a" -> uuid("x"), "b" -> uuid("const")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),
@@ -72,6 +74,7 @@ class IROptimizerTest extends AnyFlatSpec with Matchers {
           "add",
           Map("a" -> uuid("a"), "b" -> uuid("b")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),
@@ -104,6 +107,7 @@ class IROptimizerTest extends AnyFlatSpec with Matchers {
           "add",
           Map("a" -> uuid("a"), "b" -> uuid("b")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),
@@ -132,6 +136,7 @@ class IROptimizerTest extends AnyFlatSpec with Matchers {
           "add",
           Map("a" -> uuid("a"), "b" -> uuid("b")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),
@@ -236,6 +241,7 @@ class IROptimizerTest extends AnyFlatSpec with Matchers {
           "add",
           Map("a" -> uuid("input"), "b" -> uuid("lit")),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),

--- a/modules/lang-compiler/src/test/scala/io/constellation/lang/viz/DagVizCompilerTest.scala
+++ b/modules/lang-compiler/src/test/scala/io/constellation/lang/viz/DagVizCompilerTest.scala
@@ -1,6 +1,6 @@
 package io.constellation.lang.viz
 
-import io.constellation.lang.compiler.{IRNode, IRProgram}
+import io.constellation.lang.compiler.{IRModuleCallOptions, IRNode, IRProgram}
 import io.constellation.lang.semantic.SemanticType
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -43,6 +43,7 @@ class DagVizCompilerTest extends AnyFunSuite with Matchers {
           "Uppercase",
           Map("text" -> inputId),
           SemanticType.SString,
+          IRModuleCallOptions.empty,
           None
         ),
         fieldAccessId -> IRNode.FieldAccessNode(fieldAccessId, moduleId, "result", SemanticType.SString, None)
@@ -91,6 +92,7 @@ class DagVizCompilerTest extends AnyFunSuite with Matchers {
           "add",
           Map("left" -> aId, "right" -> bId),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),
@@ -138,8 +140,8 @@ class DagVizCompilerTest extends AnyFunSuite with Matchers {
     val ir = IRProgram(
       nodes = Map(
         aId -> IRNode.Input(aId, "a", SemanticType.SString, None),
-        bId -> IRNode.ModuleCall(bId, "ModuleB", "ModuleB", Map("x" -> aId), SemanticType.SString, None),
-        cId -> IRNode.ModuleCall(cId, "ModuleC", "ModuleC", Map("x" -> aId), SemanticType.SString, None),
+        bId -> IRNode.ModuleCall(bId, "ModuleB", "ModuleB", Map("x" -> aId), SemanticType.SString, IRModuleCallOptions.empty, None),
+        cId -> IRNode.ModuleCall(cId, "ModuleC", "ModuleC", Map("x" -> aId), SemanticType.SString, IRModuleCallOptions.empty, None),
         dId -> IRNode.MergeNode(dId, bId, cId, SemanticType.SRecord(Map("b" -> SemanticType.SString, "c" -> SemanticType.SString)), None)
       ),
       inputs = List(aId),
@@ -242,6 +244,7 @@ class DagVizCompilerTest extends AnyFunSuite with Matchers {
           "add",
           Map("left" -> input1Id, "right" -> input2Id),
           SemanticType.SInt,
+          IRModuleCallOptions.empty,
           None
         )
       ),


### PR DESCRIPTION
## Summary

This PR completes the module call options support by extending IR generation and DAG compilation to handle the `with` clause options.

- Add `IRModuleCallOptions` type to IR.scala for IR-level options representation
- Add `options` field to `IRNode.ModuleCall` with appropriate serialization
- Add typed fallback expression support in `TypedExpression.FunctionCall`
- Implement `convertOptions` in IRGenerator to transform AST options to IR options
- Add `moduleOptions` tracking in `DagCompiler.CompileResult`
- Update pattern matches in optimizers (CSE, ConstantFolding) for new structure
- Update DagVizCompiler to handle new ModuleCall signature

## Test plan

- [x] All 903 lang-compiler tests pass
- [x] Existing optimizer tests updated with IRModuleCallOptions.empty
- [x] Rebased on latest master

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)