### PR TITLE
fix: resolve all compilation warnings

### DIFF
--- a/modules/example-app/src/test/scala/io/constellation/examples/app/modules/DataModulesTest.scala
+++ b/modules/example-app/src/test/scala/io/constellation/examples/app/modules/DataModulesTest.scala
@@ -58,8 +58,9 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
       "numbers" -> CValue.CList(Vector(1L, 2L, 3L, 4L, 5L).map(CValue.CInt.apply), CType.CInt)
     )
 
-    val result = runModule[Long](source, "sumlist-test", inputs, "result") { case CValue.CInt(v) =>
-      v
+    val result = runModule[Long](source, "sumlist-test", inputs, "result") {
+      case CValue.CInt(v) => v
+      case other          => throw new AssertionError(s"Expected CInt but got $other")
     }
     result shouldBe 15L
   }
@@ -74,8 +75,9 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
       "numbers" -> CValue.CList(Vector.empty, CType.CInt)
     )
 
-    val result = runModule[Long](source, "sumlist-empty", inputs, "result") { case CValue.CInt(v) =>
-      v
+    val result = runModule[Long](source, "sumlist-empty", inputs, "result") {
+      case CValue.CInt(v) => v
+      case other          => throw new AssertionError(s"Expected CInt but got $other")
     }
     result shouldBe 0L
   }
@@ -92,6 +94,7 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
 
     val result = runModule[Long](source, "sumlist-single", inputs, "result") {
       case CValue.CInt(v) => v
+      case other          => throw new AssertionError(s"Expected CInt but got $other")
     }
     result shouldBe 42L
   }
@@ -108,6 +111,7 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
 
     val result = runModule[Long](source, "sumlist-negative", inputs, "result") {
       case CValue.CInt(v) => v
+      case other          => throw new AssertionError(s"Expected CInt but got $other")
     }
     result shouldBe 2L
   }
@@ -124,8 +128,9 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
       "numbers" -> CValue.CList(Vector(2L, 4L, 6L).map(CValue.CInt.apply), CType.CInt)
     )
 
-    val result = runModule[Double](source, "avg-test", inputs, "result") { case CValue.CFloat(v) =>
-      v
+    val result = runModule[Double](source, "avg-test", inputs, "result") {
+      case CValue.CFloat(v) => v
+      case other            => throw new AssertionError(s"Expected CFloat but got $other")
     }
     result shouldBe 4.0
   }
@@ -140,8 +145,9 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
       "numbers" -> CValue.CList(Vector.empty, CType.CInt)
     )
 
-    val result = runModule[Double](source, "avg-empty", inputs, "result") { case CValue.CFloat(v) =>
-      v
+    val result = runModule[Double](source, "avg-empty", inputs, "result") {
+      case CValue.CFloat(v) => v
+      case other            => throw new AssertionError(s"Expected CFloat but got $other")
     }
     result shouldBe 0.0
   }
@@ -158,6 +164,7 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
 
     val result = runModule[Double](source, "avg-single", inputs, "result") {
       case CValue.CFloat(v) => v
+      case other            => throw new AssertionError(s"Expected CFloat but got $other")
     }
     result shouldBe 100.0
   }
@@ -174,6 +181,7 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
 
     val result = runModule[Double](source, "avg-decimal", inputs, "result") {
       case CValue.CFloat(v) => v
+      case other            => throw new AssertionError(s"Expected CFloat but got $other")
     }
     result shouldBe 1.5
   }
@@ -190,8 +198,9 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
       "numbers" -> CValue.CList(Vector(3L, 7L, 2L, 9L, 1L).map(CValue.CInt.apply), CType.CInt)
     )
 
-    val result = runModule[Long](source, "max-test", inputs, "result") { case CValue.CInt(v) =>
-      v
+    val result = runModule[Long](source, "max-test", inputs, "result") {
+      case CValue.CInt(v) => v
+      case other          => throw new AssertionError(s"Expected CInt but got $other")
     }
     result shouldBe 9L
   }
@@ -206,8 +215,9 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
       "numbers" -> CValue.CList(Vector.empty, CType.CInt)
     )
 
-    val result = runModule[Long](source, "max-empty", inputs, "result") { case CValue.CInt(v) =>
-      v
+    val result = runModule[Long](source, "max-empty", inputs, "result") {
+      case CValue.CInt(v) => v
+      case other          => throw new AssertionError(s"Expected CInt but got $other")
     }
     result shouldBe 0L
   }
@@ -222,8 +232,9 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
       "numbers" -> CValue.CList(Vector(-5L, -2L, -8L).map(CValue.CInt.apply), CType.CInt)
     )
 
-    val result = runModule[Long](source, "max-negative", inputs, "result") { case CValue.CInt(v) =>
-      v
+    val result = runModule[Long](source, "max-negative", inputs, "result") {
+      case CValue.CInt(v) => v
+      case other          => throw new AssertionError(s"Expected CInt but got $other")
     }
     result shouldBe -2L
   }
@@ -240,8 +251,9 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
       "numbers" -> CValue.CList(Vector(3L, 7L, 2L, 9L, 1L).map(CValue.CInt.apply), CType.CInt)
     )
 
-    val result = runModule[Long](source, "min-test", inputs, "result") { case CValue.CInt(v) =>
-      v
+    val result = runModule[Long](source, "min-test", inputs, "result") {
+      case CValue.CInt(v) => v
+      case other          => throw new AssertionError(s"Expected CInt but got $other")
     }
     result shouldBe 1L
   }
@@ -256,8 +268,9 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
       "numbers" -> CValue.CList(Vector.empty, CType.CInt)
     )
 
-    val result = runModule[Long](source, "min-empty", inputs, "result") { case CValue.CInt(v) =>
-      v
+    val result = runModule[Long](source, "min-empty", inputs, "result") {
+      case CValue.CInt(v) => v
+      case other          => throw new AssertionError(s"Expected CInt but got $other")
     }
     result shouldBe 0L
   }
@@ -272,8 +285,9 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
       "numbers" -> CValue.CList(Vector(-5L, -2L, -8L).map(CValue.CInt.apply), CType.CInt)
     )
 
-    val result = runModule[Long](source, "min-negative", inputs, "result") { case CValue.CInt(v) =>
-      v
+    val result = runModule[Long](source, "min-negative", inputs, "result") {
+      case CValue.CInt(v) => v
+      case other          => throw new AssertionError(s"Expected CInt but got $other")
     }
     result shouldBe -8L
   }
@@ -293,7 +307,8 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
     )
 
     val result = runModule[Vector[Long]](source, "filter-test", inputs, "result") {
-      case CValue.CList(values, _) => values.map { case CValue.CInt(v) => v }
+      case CValue.CList(values, _) => values.map { case CValue.CInt(v) => v; case other => throw new AssertionError(s"Expected CInt but got $other") }
+      case other                   => throw new AssertionError(s"Expected CList but got $other")
     }
     result shouldBe Vector(5L, 8L)
   }
@@ -311,7 +326,8 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
     )
 
     val result = runModule[Vector[Long]](source, "filter-none", inputs, "result") {
-      case CValue.CList(values, _) => values.map { case CValue.CInt(v) => v }
+      case CValue.CList(values, _) => values.map { case CValue.CInt(v) => v; case other => throw new AssertionError(s"Expected CInt but got $other") }
+      case other                   => throw new AssertionError(s"Expected CList but got $other")
     }
     result shouldBe Vector.empty
   }
@@ -329,7 +345,8 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
     )
 
     val result = runModule[Vector[Long]](source, "filter-empty", inputs, "result") {
-      case CValue.CList(values, _) => values.map { case CValue.CInt(v) => v }
+      case CValue.CList(values, _) => values.map { case CValue.CInt(v) => v; case other => throw new AssertionError(s"Expected CInt but got $other") }
+      case other                   => throw new AssertionError(s"Expected CList but got $other")
     }
     result shouldBe Vector.empty
   }
@@ -349,7 +366,8 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
     )
 
     val result = runModule[Vector[Long]](source, "multiply-test", inputs, "result") {
-      case CValue.CList(values, _) => values.map { case CValue.CInt(v) => v }
+      case CValue.CList(values, _) => values.map { case CValue.CInt(v) => v; case other => throw new AssertionError(s"Expected CInt but got $other") }
+      case other                   => throw new AssertionError(s"Expected CList but got $other")
     }
     result shouldBe Vector(3L, 6L, 9L)
   }
@@ -367,7 +385,8 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
     )
 
     val result = runModule[Vector[Long]](source, "multiply-zero", inputs, "result") {
-      case CValue.CList(values, _) => values.map { case CValue.CInt(v) => v }
+      case CValue.CList(values, _) => values.map { case CValue.CInt(v) => v; case other => throw new AssertionError(s"Expected CInt but got $other") }
+      case other                   => throw new AssertionError(s"Expected CList but got $other")
     }
     result shouldBe Vector(0L, 0L)
   }
@@ -385,7 +404,8 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
     )
 
     val result = runModule[Vector[Long]](source, "multiply-neg", inputs, "result") {
-      case CValue.CList(values, _) => values.map { case CValue.CInt(v) => v }
+      case CValue.CList(values, _) => values.map { case CValue.CInt(v) => v; case other => throw new AssertionError(s"Expected CInt but got $other") }
+      case other                   => throw new AssertionError(s"Expected CList but got $other")
     }
     result shouldBe Vector(-4L, -8L)
   }
@@ -403,7 +423,8 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
     )
 
     val result = runModule[Vector[Long]](source, "multiply-empty", inputs, "result") {
-      case CValue.CList(values, _) => values.map { case CValue.CInt(v) => v }
+      case CValue.CList(values, _) => values.map { case CValue.CInt(v) => v; case other => throw new AssertionError(s"Expected CInt but got $other") }
+      case other                   => throw new AssertionError(s"Expected CList but got $other")
     }
     result shouldBe Vector.empty
   }
@@ -423,7 +444,8 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
     )
 
     val result = runModule[Vector[Long]](source, "range-test", inputs, "result") {
-      case CValue.CList(values, _) => values.map { case CValue.CInt(v) => v }
+      case CValue.CList(values, _) => values.map { case CValue.CInt(v) => v; case other => throw new AssertionError(s"Expected CInt but got $other") }
+      case other                   => throw new AssertionError(s"Expected CList but got $other")
     }
     result shouldBe Vector(1L, 2L, 3L, 4L, 5L)
   }
@@ -441,7 +463,8 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
     )
 
     val result = runModule[Vector[Long]](source, "range-single", inputs, "result") {
-      case CValue.CList(values, _) => values.map { case CValue.CInt(v) => v }
+      case CValue.CList(values, _) => values.map { case CValue.CInt(v) => v; case other => throw new AssertionError(s"Expected CInt but got $other") }
+      case other                   => throw new AssertionError(s"Expected CList but got $other")
     }
     result shouldBe Vector(5L)
   }
@@ -459,7 +482,8 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
     )
 
     val result = runModule[Vector[Long]](source, "range-neg", inputs, "result") {
-      case CValue.CList(values, _) => values.map { case CValue.CInt(v) => v }
+      case CValue.CList(values, _) => values.map { case CValue.CInt(v) => v; case other => throw new AssertionError(s"Expected CInt but got $other") }
+      case other                   => throw new AssertionError(s"Expected CList but got $other")
     }
     result shouldBe Vector(-2L, -1L, 0L, 1L, 2L)
   }
@@ -478,6 +502,7 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
 
     val result = runModule[String](source, "format-test", inputs, "result") {
       case CValue.CString(v) => v
+      case other             => throw new AssertionError(s"Expected CString but got $other")
     }
     // Formatted with locale-specific separator (could be comma or period)
     result should (include("1") and include("000") and include("000"))
@@ -495,6 +520,7 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
 
     val result = runModule[String](source, "format-small", inputs, "result") {
       case CValue.CString(v) => v
+      case other             => throw new AssertionError(s"Expected CString but got $other")
     }
     result shouldBe "42"
   }
@@ -511,6 +537,7 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
 
     val result = runModule[String](source, "format-zero", inputs, "result") {
       case CValue.CString(v) => v
+      case other             => throw new AssertionError(s"Expected CString but got $other")
     }
     result shouldBe "0"
   }
@@ -527,6 +554,7 @@ class DataModulesTest extends AnyFlatSpec with Matchers {
 
     val result = runModule[String](source, "format-neg", inputs, "result") {
       case CValue.CString(v) => v
+      case other             => throw new AssertionError(s"Expected CString but got $other")
     }
     result should startWith("-")
   }

--- a/modules/http-api/src/main/scala/io/constellation/http/CorsConfig.scala
+++ b/modules/http-api/src/main/scala/io/constellation/http/CorsConfig.scala
@@ -60,7 +60,7 @@ object CorsConfig {
       Right(origin) // Wildcard is valid
     } else {
       try {
-        val url    = new java.net.URL(origin)
+        val url    = java.net.URI(origin).toURL
         val scheme = url.getProtocol.toLowerCase
 
         // Require HTTPS unless localhost

--- a/modules/lang-compiler/src/test/scala/io/constellation/lang/benchmark/RegressionTests.scala
+++ b/modules/lang-compiler/src/test/scala/io/constellation/lang/benchmark/RegressionTests.scala
@@ -67,7 +67,7 @@ class RegressionTests extends AnyFlatSpec with Matchers with RetrySupport {
           s"Operation: ${result.name}\n" +
           s"Measured:  ${result.avgMs}ms (±${result.stdDevMs}ms)\n" +
           s"Baseline:  ${maxAllowed}ms\n" +
-          s"Exceeded by: ${((result.avgMs - maxAllowed) / maxAllowed * 100).formatted("%.1f")}%\n"
+          s"Exceeded by: ${"%.1f".format((result.avgMs - maxAllowed) / maxAllowed * 100)}%\n"
       ) {
         result.avgMs should be <= maxAllowed
       }

--- a/modules/lang-compiler/src/test/scala/io/constellation/lang/semantic/ExampleTypeCheckSpec.scala
+++ b/modules/lang-compiler/src/test/scala/io/constellation/lang/semantic/ExampleTypeCheckSpec.scala
@@ -107,8 +107,8 @@ class ExampleTypeCheckSpec extends AnyFlatSpec with Matchers {
     """
     val result = check(source)
     result.isLeft shouldBe true
-    result.left.get.head.message should include("String")
-    result.left.get.head.message should include("Int")
+    result.swap.getOrElse(throw new AssertionError("Expected Left")).head.message should include("String")
+    result.swap.getOrElse(throw new AssertionError("Expected Left")).head.message should include("Int")
   }
 
   it should "reject String example for Int input" in {
@@ -119,8 +119,8 @@ class ExampleTypeCheckSpec extends AnyFlatSpec with Matchers {
     """
     val result = check(source)
     result.isLeft shouldBe true
-    result.left.get.head.message should include("Int")
-    result.left.get.head.message should include("String")
+    result.swap.getOrElse(throw new AssertionError("Expected Left")).head.message should include("Int")
+    result.swap.getOrElse(throw new AssertionError("Expected Left")).head.message should include("String")
   }
 
   it should "reject Boolean example for String input" in {
@@ -320,7 +320,7 @@ class ExampleTypeCheckSpec extends AnyFlatSpec with Matchers {
     val result = check(source)
     result.isLeft shouldBe true
     // Should have exactly one error (for the count input)
-    result.left.get should have size 1
+    result.swap.getOrElse(throw new AssertionError("Expected Left")) should have size 1
   }
 
   // ==========================================================================
@@ -362,7 +362,7 @@ class ExampleTypeCheckSpec extends AnyFlatSpec with Matchers {
     """
     val result = check(source)
     result.isLeft shouldBe true
-    val error = result.left.get.head
+    val error = result.swap.getOrElse(throw new AssertionError("Expected Left")).head
     error.span shouldBe defined
   }
 
@@ -374,7 +374,7 @@ class ExampleTypeCheckSpec extends AnyFlatSpec with Matchers {
     """
     val result = check(source)
     result.isLeft shouldBe true
-    val errorMsg = result.left.get.head.message
+    val errorMsg = result.swap.getOrElse(throw new AssertionError("Expected Left")).head.message
     errorMsg should include("String")
     errorMsg should include("Int")
   }
@@ -713,8 +713,8 @@ class ExampleTypeCheckSpec extends AnyFlatSpec with Matchers {
     """
     val result = check(source)
     result.isLeft shouldBe true
-    result.left.get.head.message should include("List<Int>")
-    result.left.get.head.message should include("List<String>")
+    result.swap.getOrElse(throw new AssertionError("Expected Left")).head.message should include("List<Int>")
+    result.swap.getOrElse(throw new AssertionError("Expected Left")).head.message should include("List<String>")
   }
 
   it should "reject list literal with mixed element types as input example" in {
@@ -727,7 +727,7 @@ class ExampleTypeCheckSpec extends AnyFlatSpec with Matchers {
     result.isLeft shouldBe true
     // With subtyping, mixed types produce a union: List<Int | String>
     // This fails because List<Int | String> is not assignable to List<Int>
-    result.left.get.head.message should include("List<Int>")
+    result.swap.getOrElse(throw new AssertionError("Expected Left")).head.message should include("List<Int>")
   }
 
   it should "reject list literal for non-list input type" in {

--- a/modules/runtime/src/main/scala/io/constellation/execution/ErrorStrategy.scala
+++ b/modules/runtime/src/main/scala/io/constellation/execution/ErrorStrategy.scala
@@ -163,10 +163,6 @@ object ErrorStrategyExecutor {
 
     case CType.COptional(_) =>
       CValue.CNone(ctype)
-
-    case _ =>
-      // Fallback for unknown types
-      CValue.CNone(CType.COptional(ctype))
   }
 
   /** Check if a type has a meaningful zero value.
@@ -178,6 +174,5 @@ object ErrorStrategyExecutor {
     case CType.CList(_) | CType.CMap(_, _) | CType.COptional(_)     => true
     case CType.CProduct(structure) => structure.values.forall(hasZeroValue)
     case CType.CUnion(variants)    => variants.values.exists(hasZeroValue)
-    case _                         => false
   }
 }

--- a/modules/runtime/src/test/scala/io/constellation/SteppedExecutionTest.scala
+++ b/modules/runtime/src/test/scala/io/constellation/SteppedExecutionTest.scala
@@ -705,7 +705,7 @@ class SteppedExecutionTest extends AnyFlatSpec with Matchers {
 
     val result = SteppedExecution.initializeRuntime(session).attempt.unsafeRunSync()
     result.isLeft shouldBe true
-    result.left.get.getMessage should include("unexpected")
+    result.swap.getOrElse(throw new AssertionError("Expected Left")).getMessage should include("unexpected")
   }
 
   it should "fail with wrong input type" in {
@@ -744,7 +744,7 @@ class SteppedExecutionTest extends AnyFlatSpec with Matchers {
 
     val result = SteppedExecution.initializeRuntime(session).attempt.unsafeRunSync()
     result.isLeft shouldBe true
-    result.left.get.getMessage should include("different type")
+    result.swap.getOrElse(throw new AssertionError("Expected Left")).getMessage should include("different type")
   }
 
   // ===== executeToCompletion for already-complete session =====

--- a/modules/runtime/src/test/scala/io/constellation/execution/GlobalSchedulerTest.scala
+++ b/modules/runtime/src/test/scala/io/constellation/execution/GlobalSchedulerTest.scala
@@ -639,8 +639,8 @@ class GlobalSchedulerTest extends AnyFlatSpec with Matchers with RetrySupport {
           result <- scheduler.submit(50, IO.pure("q3")).attempt
 
           _ = result.isLeft shouldBe true
-          _ = result.left.get shouldBe a[QueueFullException]
-          _ = result.left.get.asInstanceOf[QueueFullException].maxSize shouldBe 2
+          _ = result.swap.getOrElse(throw new AssertionError("Expected Left")) shouldBe a[QueueFullException]
+          _ = result.swap.getOrElse(throw new AssertionError("Expected Left")).asInstanceOf[QueueFullException].maxSize shouldBe 2
 
           // Clean up
           _ <- blocker.joinWithNever


### PR DESCRIPTION
## Summary
- Remove unreachable `case _` branches in `ErrorStrategy.scala` (sealed `CType` already exhaustively matched)
- Replace deprecated `new java.net.URL()` with `java.net.URI().toURL` in `CorsConfig.scala`
- Replace deprecated `.left.get` with `.swap.getOrElse(...)` in 4 test files
- Replace deprecated `.formatted()` with `"%.1f".format(...)` in `RegressionTests.scala`
- Add exhaustive catch-all cases to 20+ partial matches in `DataModulesTest.scala`

**Result:** Zero warnings across all main and test sources.

## Test plan
- [x] `sbt clean compile` — zero warnings
- [x] Per-module `Test/compile` — zero warnings across all 9 modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)