### PR TITLE
docs(rfc): accept RFC-030, draft RFC-031

### DIFF
--- a/rfcs/rfc-030-lambda-closures.md
+++ b/rfcs/rfc-030-lambda-closures.md
@@ -1,6 +1,6 @@
 # RFC-030: Lambda Closure Support
 
-- **Status:** Draft
+- **Status:** Accepted
 - **Created:** 2026-02-15
 - **Author:** Claude (discovered during RFC-029 demo QA)
 
@@ -47,38 +47,68 @@ outer-scope variable throws:
 java.lang.IllegalStateException: Undefined variable in IR generation: <varname>
 ```
 
-**Crash severity:** This is an unrecoverable crash that terminates the
-PipelineLoader and crashes the server if the pipeline is auto-loaded from
-the `CST_DIR`. Even though PipelineLoader logs compilation warnings for
-other errors, an `IllegalStateException` during IR generation bypasses
-the error handling.
+**Crash severity:** ~~This is an unrecoverable crash that terminates the
+PipelineLoader and crashes the server.~~ Fixed in PR #223 — PipelineLoader now
+catches unexpected exceptions via `.handleErrorWith` and reports them as
+compilation failures. The underlying `IRGenerator` limitation remains: closures
+are not supported and produce a compile-time error.
 
 ## Proposed Solution
 
-### Phase 1: Closure Variable Capture
+### Phase 1: Graceful Error Handling — SHIPPED
 
-Modify `IRGenerator.generateLambdaIR` to:
+Merged in PR #223 (`fix/pipeline-loader-crash`). PipelineLoader now catches
+exceptions from `compileIO` via `.handleErrorWith` in both `compileAndStore`
+and `processFilesBatched`, converting them to graceful `FileResult.Failed` /
+`CompileResult` errors with WARN-level logging. Closure `.cst` files are
+reported as compilation failures instead of crashing the server.
 
-1. Build a "capture set" of variables referenced in the lambda body that are
-   not lambda parameters
-2. Resolve these variables from the enclosing scope at the call site
-3. Pass captured values as additional context to the `InlineTransform` node
+### Phase 2: Closure Variable Capture
 
-### Phase 2: Graceful Error Handling
+Closures are implemented as **inline modules with extra data node inputs**.
+The lambda compiles into a self-contained sub-DAG (`TypedLambda.bodyNodes`).
+Today the only inputs are the lambda parameters. Captured variables become
+additional nodes copied into the sub-DAG from the outer scope.
 
-Regardless of closure support, `PipelineLoader.processFile` should catch
-`IllegalStateException` from IR generation and log a warning instead of
-crashing the server.
+Implementation:
+
+1. `generateLambdaIR` accepts the enclosing `GenContext` (currently uses
+   `GenContext.empty`)
+2. When `VarRef` resolves a name not in the lambda parameters, it looks up
+   the node ID in the enclosing context
+3. The referenced outer node (and its transitive dependencies) are **copied**
+   into the lambda's `bodyNodes` map, making the sub-DAG self-contained
+4. At runtime, `HigherOrderNode` executes the lambda body as before — the
+   captured values are just regular nodes in `bodyNodes`, no special handling
+
+This is the **copy** strategy: the lambda sub-DAG owns all the nodes it
+needs. No runtime merging of execution contexts required.
+
+## Scoping Semantics
+
+Closures use **by-value capture** (snapshot at lambda creation time). Captured
+variables are resolved from the enclosing scope at the call site and their
+nodes are copied into the lambda's sub-DAG. This is the natural fit for the
+DAG execution model where node outputs are immutable values.
+
+## Type Checker Interaction
+
+The type checker **already accepts** lambdas with captured variables — it
+resolves them correctly from the enclosing scope. The crash only occurs later
+during IR generation, where `generateLambdaIR` uses `GenContext.empty` and
+loses the enclosing scope. No type checker changes are needed.
 
 ## Key Files
 
 - `modules/lang-compiler/src/main/scala/io/constellation/lang/compiler/IRGenerator.scala`
-  - `generateLambdaIR` - lambda IR generation
-  - `generateHigherOrderCall` - higher-order function call handling
+  - `generateLambdaIR` — uses `GenContext.empty` (root cause)
+  - `generateHigherOrderCall` — has outer `ctx` that should be passed through
 - `modules/lang-compiler/src/main/scala/io/constellation/lang/compiler/InlineTransform.scala`
   - Runtime execution of inline-expanded lambdas
+- `modules/lang-compiler/src/main/scala/io/constellation/lang/LangCompiler.scala`
+  - `compileIO` wraps `compile` in `IO(...)` — exception becomes failed IO
 - `modules/http-api/src/main/scala/io/constellation/http/PipelineLoader.scala`
-  - Pipeline auto-loading (crash site for the error handling issue)
+  - Pipeline auto-loading (crash fix already shipped in PR #223)
 
 ## Test Cases
 
@@ -93,11 +123,33 @@ in numbers: List<Int>
 avg = Average(numbers)
 aboveAvg = filter(numbers, (x) => gt(x, avg))
 
-# Nested closures (stretch goal)
+# Shadowing: lambda param shadows outer variable
+in x: Int
+in numbers: List<Int>
+result = filter(numbers, (x) => gt(x, 0))
+# Expected: lambda param `x` shadows outer `x`, no ambiguity
+```
+
+### Nested Closures (Phase 3 — separate follow-up)
+
+Nested closures require capturing variables across **two lambda boundaries**
+(e.g., `minVal` captured through both the outer `map` lambda and the inner
+`filter` lambda). This is a significant implementation complexity jump and
+should be deferred to a follow-up:
+
+```constellation
+# Nested closures — requires multi-level capture
 in matrix: List<List<Int>>
 in minVal: Int
 filtered = map(matrix, (row) => filter(row, (x) => gt(x, minVal)))
 ```
+
+## Performance Considerations
+
+Closures add captured values as additional node references in the lambda's
+`bodyNodes` map. Since captured values are just existing DAG node IDs (UUIDs),
+the overhead is minimal — a few extra entries per closure. No serialization
+impact expected for typical use cases.
 
 ## Alternatives Considered
 
@@ -110,5 +162,12 @@ filtered = map(matrix, (row) => filter(row, (x) => gt(x, minVal)))
 
 ## Priority
 
-P1 - This is a fundamental expressiveness limitation that users will commonly
-encounter when writing real-world pipelines.
+- **Phase 1 (crash fix):** P0 — SHIPPED (PR #223)
+- **Phase 2 (closures):** P1 — fundamental expressiveness limitation that
+  users will commonly encounter when writing real-world pipelines
+- **Phase 3 (nested closures):** P2 — advanced feature, deferred
+
+## Related RFCs
+
+- **RFC-031:** IRGenerator error handling refactor (return `Either` instead of
+  throwing) — spun out from this RFC's review as an independent improvement

--- a/rfcs/rfc-031-ir-generator-error-handling.md
+++ b/rfcs/rfc-031-ir-generator-error-handling.md
@@ -1,0 +1,139 @@
+# RFC-031: IRGenerator Error Handling Refactor
+
+- **Status:** Draft
+- **Created:** 2026-02-16
+- **Author:** Claude (discovered during RFC-030 review)
+
+## Summary
+
+Refactor `IRGenerator` to return compilation errors via `Either` instead of
+throwing `IllegalStateException`, making the compiler pipeline robust against
+unexpected IR generation failures without requiring defensive `try/catch` or
+`.handleErrorWith` at every call site.
+
+## Motivation
+
+`IRGenerator` currently throws `IllegalStateException` for unrecoverable
+conditions (undefined variables, lambdas in invalid contexts, unknown
+higher-order functions). These exceptions bypass the compiler's structured
+error path (`Either[List[CompileError], ...]`) and surface as failed IO
+effects that callers must catch individually.
+
+This already caused a P0 server crash (PR #223): `PipelineLoader` called
+`compileIO` which wraps `compile` in `IO(...)`. When `IRGenerator` threw,
+the exception became a failed IO that bypassed the `Left(errors)` handler
+and crashed the server. The fix was adding `.handleErrorWith` at the call
+site — but this is defensive, not structural.
+
+### Problems with Throwing
+
+1. **Every caller must defend independently.** Any new code calling
+   `compile` / `compileIO` must remember to catch exceptions. Forgetting
+   causes silent crash vectors.
+2. **Error messages are poor.** `IllegalStateException` loses source span
+   information. Structured `CompileError` includes file location, severity,
+   and context for LSP diagnostics.
+3. **Inconsistent error model.** Parse errors and type errors flow through
+   `Either[List[CompileError], ...]`. IR generation errors throw. Callers
+   see two different failure modes from the same `compile()` call.
+
+## Proposed Solution
+
+### Change `IRGenerator.generate` Return Type
+
+```scala
+// Before
+def generate(program: TypedPipeline): IRPipeline
+
+// After
+def generate(program: TypedPipeline): Either[List[CompileError], IRPipeline]
+```
+
+### Replace `throw` with `Left`
+
+There are currently 3 throw sites in `IRGenerator`:
+
+| Location | Current Exception | Proposed CompileError |
+|----------|-------------------|----------------------|
+| `VarRef` case (line ~90) | `IllegalStateException("Undefined variable in IR generation: $name")` | `CompileError.undefinedVariable(name, span)` |
+| `Lambda` case (line ~249) | `IllegalStateException("Lambda expression at $span cannot be used in this context...")` | `CompileError.invalidLambdaContext(span)` |
+| `getHigherOrderOp` (line ~307) | `IllegalArgumentException("Unknown higher-order function: $moduleName")` | `CompileError.unknownHigherOrderFunction(moduleName, span)` |
+
+### Thread `Either` Through Internal Methods
+
+`generateExpression` and `generateDeclarations` currently return
+`(GenContext, UUID)`. After the refactor:
+
+```scala
+// Before
+private def generateExpression(expr: TypedExpression, ctx: GenContext): (GenContext, UUID)
+
+// After
+private def generateExpression(
+    expr: TypedExpression, ctx: GenContext
+): Either[List[CompileError], (GenContext, UUID)]
+```
+
+This threads errors up through the call chain without exceptions.
+
+### Update `LangCompilerImpl.compile`
+
+The `compile` method chains parse → type-check → IR generation. Currently
+IR generation is the only step that can throw. After the refactor, it returns
+`Either` like the other steps:
+
+```scala
+// Simplified flow
+for {
+  parsed     <- parser.parse(source)           // Either
+  typed      <- typeChecker.check(parsed)      // Either
+  ir         <- IRGenerator.generate(typed)    // Either (NEW)
+  pipeline   <- DagCompiler.compile(ir, ...)   // Either
+} yield pipeline
+```
+
+## Key Files
+
+- `modules/lang-compiler/src/main/scala/io/constellation/lang/compiler/IRGenerator.scala`
+  — all 3 throw sites, `generate`, `generateExpression`, `generateDeclarations`
+- `modules/lang-compiler/src/main/scala/io/constellation/lang/compiler/CompilerError.scala`
+  — add new error variants for IR generation failures
+- `modules/lang-compiler/src/main/scala/io/constellation/lang/LangCompilerImpl.scala`
+  — update `compile` to handle `Either` from IR generation
+- `modules/lang-compiler/src/main/scala/io/constellation/lang/compiler/DagCompiler.scala`
+  — may need adjustment if it calls `IRGenerator.generate` directly
+
+## Impact
+
+### PipelineLoader `.handleErrorWith` — Keep or Remove?
+
+The `.handleErrorWith` added in PR #223 becomes redundant for IR generation
+errors since they would flow through `Left`. However, **keep it** — it
+provides defense-in-depth against future unexpected exceptions from any part
+of the compilation pipeline (parser bugs, serialization errors, etc.).
+
+### LSP Diagnostics
+
+Structured `CompileError` from IR generation means the LSP server can show
+proper diagnostics for closure errors (red squiggly on the captured variable)
+instead of silent failures.
+
+### Test Impact
+
+Existing tests that use `intercept[IllegalStateException]` (e.g.,
+`CompilerErrorTest`) would need updating to check for `Left(errors)` instead.
+
+## Alternatives Considered
+
+1. **Wrap throws in `Try` at the `compile` boundary** — simpler but still
+   loses span information and keeps the inconsistent error model
+2. **Use `MonadError` / `EitherT`** — more principled but adds complexity
+   to the internal API for limited benefit in synchronous code
+3. **Keep throwing, add more `.handleErrorWith`** — current approach,
+   works but fragile
+
+## Priority
+
+P2 — This is a code quality improvement that reduces crash risk and improves
+error reporting. Not blocking any features, but should be done before adding
+more IR generation features (like closures in RFC-030).


### PR DESCRIPTION
## Summary

- **RFC-030 (Accepted):** Lambda closure support — closures as inline modules with copied outer nodes, by-value capture, Phase 1 crash fix already shipped
- **RFC-031 (Draft):** IRGenerator error handling refactor — return `Either` instead of throwing

## Test plan

- [ ] Documentation only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)