### PR TITLE
feat(compiler): implement lambda closure support (RFC-030)

### DIFF
--- a/modules/lang-compiler/src/main/scala/io/constellation/lang/optimizer/CommonSubexpressionElimination.scala
+++ b/modules/lang-compiler/src/main/scala/io/constellation/lang/optimizer/CommonSubexpressionElimination.scala
@@ -113,7 +113,7 @@ object CommonSubexpressionElimination extends OptimizationPass {
       s"interp:${parts.mkString("|")}:$exprSig"
 
     // Higher-order nodes - don't deduplicate (lambda bodies are complex)
-    case IRNode.HigherOrderNode(_, _, _, _, _, _) => ""
+    case IRNode.HigherOrderNode(_, _, _, _, _, _, _) => ""
 
     // List literals
     case IRNode.ListLiteralNode(_, elements, elementType, _) =>

--- a/modules/lang-compiler/src/main/scala/io/constellation/lang/optimizer/DeadCodeElimination.scala
+++ b/modules/lang-compiler/src/main/scala/io/constellation/lang/optimizer/DeadCodeElimination.scala
@@ -61,7 +61,7 @@ object DeadCodeElimination extends OptimizationPass {
         ir.dependencies(id).foreach(visit)
         // Also visit lambda body nodes for higher-order nodes
         ir.nodes.get(id).foreach {
-          case IRNode.HigherOrderNode(_, _, _, lambda, _, _) =>
+          case IRNode.HigherOrderNode(_, _, _, lambda, _, _, _) =>
             lambda.bodyNodes.keys.foreach { lambdaNodeId =>
               // Only mark the lambda nodes themselves as reachable
               // (they're stored separately but we should track them)

--- a/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/DagVizCompiler.scala
+++ b/modules/lang-compiler/src/main/scala/io/constellation/lang/viz/DagVizCompiler.scala
@@ -185,7 +185,7 @@ object DagVizCompiler:
           typeSignature = "String"
         )
 
-      case IRNode.HigherOrderNode(_, operation, _, _, outputType, _) =>
+      case IRNode.HigherOrderNode(_, operation, _, _, outputType, _, _) =>
         val opName = operation match {
           case HigherOrderOp.Filter => "filter"
           case HigherOrderOp.Map    => "map"
@@ -244,7 +244,7 @@ object DagVizCompiler:
       case IRNode.CoalesceNode(_, _, _, resultType, _)       => resultType
       case IRNode.BranchNode(_, _, _, resultType, _)         => resultType
       case IRNode.StringInterpolationNode(_, _, _, _)        => SemanticType.SString
-      case IRNode.HigherOrderNode(_, _, _, _, outputType, _) => outputType
+      case IRNode.HigherOrderNode(_, _, _, _, outputType, _, _) => outputType
       case IRNode.ListLiteralNode(_, _, elementType, _)      => SemanticType.SList(elementType)
       case IRNode.RecordLitNode(_, _, outputType, _)         => outputType
       case IRNode.MatchNode(_, _, _, resultType, _)          => resultType
@@ -384,10 +384,24 @@ object DagVizCompiler:
             )
           }
 
-        case IRNode.HigherOrderNode(_, _, source, _, _, _) =>
-          List(
-            VizEdge(nextEdgeId(), source.toString, targetId.toString, Some("source"), EdgeKind.Data)
+        case IRNode.HigherOrderNode(_, _, source, _, _, capturedInputs, _) =>
+          val sourceEdge = VizEdge(
+            nextEdgeId(),
+            source.toString,
+            targetId.toString,
+            Some("source"),
+            EdgeKind.Data
           )
+          val capturedEdges = capturedInputs.map { case (name, outerNodeId) =>
+            VizEdge(
+              nextEdgeId(),
+              outerNodeId.toString,
+              targetId.toString,
+              Some(name),
+              EdgeKind.Data
+            )
+          }.toList
+          sourceEdge :: capturedEdges
 
         case IRNode.ListLiteralNode(_, elements, _, _) =>
           elements.zipWithIndex.map { case (elemId, idx) =>

--- a/modules/lang-compiler/src/test/scala/io/constellation/lang/compiler/ClosureTest.scala
+++ b/modules/lang-compiler/src/test/scala/io/constellation/lang/compiler/ClosureTest.scala
@@ -1,0 +1,406 @@
+package io.constellation.lang.compiler
+
+import io.constellation.*
+import io.constellation.lang.LangCompiler
+import io.constellation.lang.semantic.*
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/** Integration tests for lambda closure support (RFC-030). Verifies that lambdas can capture
+  * variables from their enclosing scope and that the compiled DAG correctly wires captured data
+  * dependencies.
+  */
+class ClosureTest extends AnyFlatSpec with Matchers {
+
+  // ===== Test Helper =====
+
+  /** Creates a LangCompiler with HOF functions (filter, map, all, any), comparison (gt, lt), and
+    * arithmetic (add, multiply) registered.
+    */
+  private def closureCompiler: LangCompiler = {
+    val registry = FunctionRegistry.empty
+    // filter: (List<Int>, (Int) => Boolean) => List<Int>
+    registry.register(
+      FunctionSignature(
+        name = "filter",
+        params = List(
+          "items"     -> SemanticType.SList(SemanticType.SInt),
+          "predicate" -> SemanticType.SFunction(List(SemanticType.SInt), SemanticType.SBoolean)
+        ),
+        returns = SemanticType.SList(SemanticType.SInt),
+        moduleName = "stdlib.hof.filter-int",
+        namespace = Some("stdlib.collection")
+      )
+    )
+    // map: (List<Int>, (Int) => Int) => List<Int>
+    registry.register(
+      FunctionSignature(
+        name = "map",
+        params = List(
+          "items"     -> SemanticType.SList(SemanticType.SInt),
+          "transform" -> SemanticType.SFunction(List(SemanticType.SInt), SemanticType.SInt)
+        ),
+        returns = SemanticType.SList(SemanticType.SInt),
+        moduleName = "stdlib.hof.map-int-int",
+        namespace = Some("stdlib.collection")
+      )
+    )
+    // all: (List<Int>, (Int) => Boolean) => Boolean
+    registry.register(
+      FunctionSignature(
+        name = "all",
+        params = List(
+          "items"     -> SemanticType.SList(SemanticType.SInt),
+          "predicate" -> SemanticType.SFunction(List(SemanticType.SInt), SemanticType.SBoolean)
+        ),
+        returns = SemanticType.SBoolean,
+        moduleName = "stdlib.hof.all-int",
+        namespace = Some("stdlib.collection")
+      )
+    )
+    // any: (List<Int>, (Int) => Boolean) => Boolean
+    registry.register(
+      FunctionSignature(
+        name = "any",
+        params = List(
+          "items"     -> SemanticType.SList(SemanticType.SInt),
+          "predicate" -> SemanticType.SFunction(List(SemanticType.SInt), SemanticType.SBoolean)
+        ),
+        returns = SemanticType.SBoolean,
+        moduleName = "stdlib.hof.any-int",
+        namespace = Some("stdlib.collection")
+      )
+    )
+    // Comparison functions
+    registry.register(
+      FunctionSignature(
+        name = "gt",
+        params = List("a" -> SemanticType.SInt, "b" -> SemanticType.SInt),
+        returns = SemanticType.SBoolean,
+        moduleName = "stdlib.gt",
+        namespace = Some("stdlib.compare")
+      )
+    )
+    registry.register(
+      FunctionSignature(
+        name = "lt",
+        params = List("a" -> SemanticType.SInt, "b" -> SemanticType.SInt),
+        returns = SemanticType.SBoolean,
+        moduleName = "stdlib.lt",
+        namespace = Some("stdlib.compare")
+      )
+    )
+    // Arithmetic functions
+    registry.register(
+      FunctionSignature(
+        name = "add",
+        params = List("a" -> SemanticType.SInt, "b" -> SemanticType.SInt),
+        returns = SemanticType.SInt,
+        moduleName = "stdlib.add",
+        namespace = Some("stdlib.math")
+      )
+    )
+    registry.register(
+      FunctionSignature(
+        name = "multiply",
+        params = List("a" -> SemanticType.SInt, "b" -> SemanticType.SInt),
+        returns = SemanticType.SInt,
+        moduleName = "stdlib.multiply",
+        namespace = Some("stdlib.math")
+      )
+    )
+    LangCompiler(registry, Map.empty)
+  }
+
+  // ===== Basic Closure Tests =====
+
+  "ClosureTest" should "compile filter with captured input variable" in {
+    val compiler = closureCompiler
+    val source =
+      """use stdlib.collection
+        |use stdlib.compare
+        |
+        |in numbers: List<Int>
+        |in threshold: Int
+        |
+        |above = filter(numbers, (x) => gt(x, threshold))
+        |out above""".stripMargin
+
+    val result = compiler.compile(source, "closure-filter-dag")
+    result.isRight shouldBe true
+
+    val compiled = result.toOption.get
+    // Should have a closure filter transform (not a plain FilterTransform)
+    compiled.pipeline.image.dagSpec.data.values.exists(d =>
+      d.name.contains("hof") && d.inlineTransform.exists(
+        _.isInstanceOf[InlineTransform.ClosureFilterTransform]
+      )
+    ) shouldBe true
+
+    // The HOF data node should have "threshold" in its transformInputs (besides "source")
+    val hofNode = compiled.pipeline.image.dagSpec.data.values
+      .find(d => d.name.contains("hof"))
+      .get
+    hofNode.transformInputs.keys should contain("threshold")
+    hofNode.transformInputs.keys should contain("source")
+  }
+
+  it should "compile filter with captured computed value" in {
+    val compiler = closureCompiler
+    // Register an Average module to simulate a computed value
+    val registry = compiler.functionRegistry
+    registry.register(
+      FunctionSignature(
+        name = "Average",
+        params = List("items" -> SemanticType.SList(SemanticType.SInt)),
+        returns = SemanticType.SInt,
+        moduleName = "example.average"
+      )
+    )
+    val compilerWithAvg = LangCompiler(registry, Map.empty)
+
+    val source =
+      """use stdlib.collection
+        |use stdlib.compare
+        |
+        |in numbers: List<Int>
+        |
+        |avg = Average(numbers)
+        |aboveAvg = filter(numbers, (x) => gt(x, avg))
+        |out aboveAvg""".stripMargin
+
+    val result = compilerWithAvg.compile(source, "closure-computed-dag")
+    result.isRight shouldBe true
+
+    val compiled = result.toOption.get
+    compiled.pipeline.image.dagSpec.data.values.exists(d =>
+      d.name.contains("hof") && d.inlineTransform.exists(
+        _.isInstanceOf[InlineTransform.ClosureFilterTransform]
+      )
+    ) shouldBe true
+  }
+
+  it should "compile filter with shadowed variable (lambda param wins)" in {
+    val compiler = closureCompiler
+    val source =
+      """use stdlib.collection
+        |use stdlib.compare
+        |
+        |in x: Int
+        |in numbers: List<Int>
+        |
+        |result = filter(numbers, (x) => gt(x, 0))
+        |out result""".stripMargin
+
+    val result = compiler.compile(source, "closure-shadow-dag")
+    result.isRight shouldBe true
+
+    val compiled = result.toOption.get
+    // With shadowing, lambda param `x` hides outer `x` — no closure capture needed
+    compiled.pipeline.image.dagSpec.data.values.exists(d =>
+      d.name.contains("hof") && d.inlineTransform.exists(
+        _.isInstanceOf[InlineTransform.FilterTransform]
+      )
+    ) shouldBe true
+  }
+
+  it should "compile filter with multiple captured variables" in {
+    val compiler = closureCompiler
+    val source =
+      """use stdlib.collection
+        |use stdlib.compare
+        |
+        |in numbers: List<Int>
+        |in lower: Int
+        |in upper: Int
+        |
+        |inRange = filter(numbers, (x) => gt(x, lower) and lt(x, upper))
+        |out inRange""".stripMargin
+
+    val result = compiler.compile(source, "closure-multi-capture-dag")
+    result.isRight shouldBe true
+
+    val compiled = result.toOption.get
+    compiled.pipeline.image.dagSpec.data.values.exists(d =>
+      d.name.contains("hof") && d.inlineTransform.exists(
+        _.isInstanceOf[InlineTransform.ClosureFilterTransform]
+      )
+    ) shouldBe true
+
+    // Both captured variables should be in transformInputs
+    val hofNode = compiled.pipeline.image.dagSpec.data.values
+      .find(d => d.name.contains("hof"))
+      .get
+    hofNode.transformInputs.keys should contain("lower")
+    hofNode.transformInputs.keys should contain("upper")
+  }
+
+  it should "compile map with closure (captured offset)" in {
+    val compiler = closureCompiler
+    val source =
+      """use stdlib.collection
+        |use stdlib.math
+        |
+        |in numbers: List<Int>
+        |in offset: Int
+        |
+        |shifted = map(numbers, (x) => add(x, offset))
+        |out shifted""".stripMargin
+
+    val result = compiler.compile(source, "closure-map-dag")
+    result.isRight shouldBe true
+
+    val compiled = result.toOption.get
+    compiled.pipeline.image.dagSpec.data.values.exists(d =>
+      d.name.contains("hof") && d.inlineTransform.exists(
+        _.isInstanceOf[InlineTransform.ClosureMapTransform]
+      )
+    ) shouldBe true
+  }
+
+  it should "compile all with closure (captured threshold)" in {
+    val compiler = closureCompiler
+    val source =
+      """use stdlib.collection
+        |use stdlib.compare
+        |
+        |in numbers: List<Int>
+        |in threshold: Int
+        |
+        |allAbove = all(numbers, (x) => gt(x, threshold))
+        |out allAbove""".stripMargin
+
+    val result = compiler.compile(source, "closure-all-dag")
+    result.isRight shouldBe true
+
+    val compiled = result.toOption.get
+    compiled.pipeline.image.dagSpec.data.values.exists(d =>
+      d.name.contains("hof") && d.inlineTransform.exists(
+        _.isInstanceOf[InlineTransform.ClosureAllTransform]
+      )
+    ) shouldBe true
+  }
+
+  it should "compile any with closure (captured threshold)" in {
+    val compiler = closureCompiler
+    val source =
+      """use stdlib.collection
+        |use stdlib.compare
+        |
+        |in numbers: List<Int>
+        |in threshold: Int
+        |
+        |anyAbove = any(numbers, (x) => gt(x, threshold))
+        |out anyAbove""".stripMargin
+
+    val result = compiler.compile(source, "closure-any-dag")
+    result.isRight shouldBe true
+
+    val compiled = result.toOption.get
+    compiled.pipeline.image.dagSpec.data.values.exists(d =>
+      d.name.contains("hof") && d.inlineTransform.exists(
+        _.isInstanceOf[InlineTransform.ClosureAnyTransform]
+      )
+    ) shouldBe true
+  }
+
+  // ===== IR-Level Verification =====
+
+  it should "generate TypedLambda with capturedBindings for closures" in {
+    val compiler = closureCompiler
+    val source =
+      """use stdlib.collection
+        |use stdlib.compare
+        |
+        |in numbers: List<Int>
+        |in threshold: Int
+        |
+        |above = filter(numbers, (x) => gt(x, threshold))
+        |out above""".stripMargin
+
+    val irResult = compiler.compileToIR(source, "closure-ir-test")
+    irResult.isRight shouldBe true
+
+    val ir = irResult.toOption.get
+    // Find the HigherOrderNode
+    val hofNode = ir.nodes.values.collectFirst { case h: IRNode.HigherOrderNode => h }
+    hofNode shouldBe defined
+
+    val hof = hofNode.get
+    // Lambda should have capturedBindings for "threshold"
+    hof.lambda.capturedBindings should contain key "threshold"
+
+    // HigherOrderNode should have capturedInputs mapping to outer context
+    hof.capturedInputs should contain key "threshold"
+  }
+
+  it should "not generate capturedBindings when lambda has no free variables" in {
+    val compiler = closureCompiler
+    val source =
+      """use stdlib.collection
+        |use stdlib.compare
+        |
+        |in numbers: List<Int>
+        |
+        |positive = filter(numbers, (x) => gt(x, 0))
+        |out positive""".stripMargin
+
+    val irResult = compiler.compileToIR(source, "no-closure-ir-test")
+    irResult.isRight shouldBe true
+
+    val ir = irResult.toOption.get
+    val hofNode = ir.nodes.values.collectFirst { case h: IRNode.HigherOrderNode => h }
+    hofNode shouldBe defined
+
+    // No closure capture — lambda only uses its own param and a literal
+    hofNode.get.lambda.capturedBindings shouldBe empty
+    hofNode.get.capturedInputs shouldBe empty
+  }
+
+  // ===== Backwards Compatibility =====
+
+  it should "still compile non-closure lambdas with FilterTransform" in {
+    val compiler = closureCompiler
+    val source =
+      """use stdlib.collection
+        |use stdlib.compare
+        |
+        |in items: List<Int>
+        |result = filter(items, (x) => gt(x, 0))
+        |out result""".stripMargin
+
+    val result = compiler.compile(source, "compat-filter-dag")
+    result.isRight shouldBe true
+
+    val compiled = result.toOption.get
+    // No captured variables -> plain FilterTransform (not ClosureFilterTransform)
+    compiled.pipeline.image.dagSpec.data.values.exists(d =>
+      d.name.contains("hof") && d.inlineTransform.exists(
+        _.isInstanceOf[InlineTransform.FilterTransform]
+      )
+    ) shouldBe true
+  }
+
+  it should "still compile non-closure lambdas with MapTransform" in {
+    val compiler = closureCompiler
+    val source =
+      """use stdlib.collection
+        |use stdlib.math
+        |
+        |in items: List<Int>
+        |result = map(items, (x) => multiply(x, 2))
+        |out result""".stripMargin
+
+    val result = compiler.compile(source, "compat-map-dag")
+    result.isRight shouldBe true
+
+    val compiled = result.toOption.get
+    // No captured variables -> plain MapTransform (not ClosureMapTransform)
+    compiled.pipeline.image.dagSpec.data.values.exists(d =>
+      d.name.contains("hof") && d.inlineTransform.exists(
+        _.isInstanceOf[InlineTransform.MapTransform]
+      )
+    ) shouldBe true
+  }
+}

--- a/organon/features/README.md
+++ b/organon/features/README.md
@@ -15,6 +15,7 @@ Feature-driven documentation organized by what Constellation does, not how it's 
 | [execution/](./execution/) | Hot, cold, and suspended execution modes | runtime, http-api |
 | [extensibility/](./extensibility/) | SPI for cache, metrics, listeners; module provider protocol for cross-process modules | runtime, module-provider-sdk, module-provider |
 | [tooling/](./tooling/) | Dashboard, LSP, VSCode extension | http-api, lang-lsp |
+| [lambda-closures/](./lambda-closures/) | Lambda expressions capturing outer-scope variables | core, lang-compiler |
 
 ## Structure
 

--- a/organon/features/lambda-closures/ETHOS.md
+++ b/organon/features/lambda-closures/ETHOS.md
@@ -1,0 +1,130 @@
+# Lambda Closures Ethos
+
+> Behavioral constraints for LLMs working on closure support.
+
+---
+
+## Core Invariants
+
+1. **Closures are self-contained.** A lambda's `bodyNodes` map contains all nodes needed to evaluate it — parameter inputs, captured variable inputs, and body computation nodes. No runtime context merging.
+
+2. **Capture is by-value.** Captured variables snapshot the DAG node output at execution time. There is no mutable reference capture. DAG nodes produce exactly one immutable value.
+
+3. **Lambda parameters shadow outer variables.** If a lambda parameter has the same name as an outer variable, the parameter wins. The outer variable is NOT captured.
+
+4. **No capture means no closure overhead.** Lambdas without free variables use plain transforms (`FilterTransform`, `MapTransform`). Closure transforms (`ClosureFilterTransform`, etc.) are only used when `capturedBindings` is non-empty.
+
+5. **Free variable analysis is exhaustive.** `collectFreeVars` must handle every `TypedExpression` variant. A missing case means a captured variable could be silently dropped, producing wrong results at runtime.
+
+---
+
+## Design Constraints
+
+### When Modifying IR.scala (TypedLambda, HigherOrderNode)
+
+- **Keep `capturedBindings` defaulted to `Map.empty`.** Non-closure lambdas must work without specifying this field.
+- **Keep `capturedInputs` defaulted to `Map.empty`.** Same reason — backwards compatibility.
+- **`capturedBindings` maps to bodyNodes UUIDs.** The values are Input node IDs *inside* the lambda's `bodyNodes`, not outer context IDs.
+- **`capturedInputs` maps to outer context UUIDs.** The values are node IDs in the *enclosing* IR pipeline, used by DagCompiler to wire data dependencies.
+- **Update `dependencies` when changing capture.** `IRPipeline.dependencies` must include `capturedInputs` values so topological sort resolves captured nodes before the HOF node.
+
+### When Modifying IRGenerator.scala (generateLambdaIR, collectFreeVars)
+
+- **Pass the outer `GenContext` to `generateLambdaIR`.** The outer context provides variable bindings and node types for captured variables.
+- **Create fresh `IRNode.Input` for each captured variable.** Do not reuse the outer node ID inside the lambda body — the lambda must be self-contained.
+- **Only capture variables that exist in outer context.** If a name is not in outer context, it's not a free variable (it will cause an error through normal name resolution).
+- **Exhaustive match in `collectFreeVars`.** Every `TypedExpression` case must be handled. Use `case _ =>` only as a safety net, never as the primary handler for expression variants.
+- **Recurse into sub-expressions.** `collectFreeVars` must recurse into function arguments, conditional branches, binary operators, and all nested structures.
+
+### When Modifying InlineTransform.scala (Closure*Transform)
+
+- **Closure transforms extract captured values from `inputs`.** The `inputs` map contains both `"source"` (the list) and captured variable values keyed by name.
+- **Keep non-closure transforms unchanged.** Plain `FilterTransform`, `MapTransform`, etc. must not be modified — they handle the common case without map lookups.
+- **Evaluator signature is `(Any, Map[String, Any]) => ReturnType`.** Element first, captured values second. This matches how `evaluateLambdaBodyUnsafe` receives bindings.
+
+### When Modifying DagCompiler.scala (processHigherOrderNode)
+
+- **Resolve captured variable UUIDs to data node IDs.** `capturedInputs` contains IR node UUIDs; `transformInputs` needs DagSpec data node UUIDs. Use `getNodeOutput` to resolve.
+- **Add captured data IDs to `transformInputs`.** The transform needs both `"source"` and all captured variable data to execute.
+- **Dispatch to closure evaluator when `capturedBindings.nonEmpty`.** Check at transform creation time, not at runtime.
+- **`evaluateLambdaBodyUnsafe` bindings include both params and captures.** The `allBindings` map merges lambda parameter bindings with captured value bindings. Lambda params take precedence (shadowing).
+
+---
+
+## Decision Heuristics
+
+### "Should this variable be captured?"
+
+**Yes** if:
+- It appears in the lambda body as a `VarRef`
+- It is NOT one of the lambda's own parameter names
+- It resolves to a binding in the outer `GenContext`
+
+**No** if:
+- It is a lambda parameter (shadowed)
+- It is a literal value (no capture needed)
+- It is a function name (resolved separately via `FunctionCall`)
+
+### "Should this use a plain or closure transform?"
+
+**Plain** (`FilterTransform`, `MapTransform`, etc.) if:
+- `capturedBindings` is empty
+- The lambda only references its own parameters and literals
+
+**Closure** (`ClosureFilterTransform`, etc.) if:
+- `capturedBindings` is non-empty
+- The lambda references at least one outer-scope variable
+
+### "How do I add a new HOF operation with closure support?"
+
+1. Add the `HigherOrderOp` variant (e.g., `SortBy`)
+2. Add a plain transform in `InlineTransform` (e.g., `SortByTransform`)
+3. Add a closure variant in `InlineTransform` (e.g., `ClosureSortByTransform`)
+4. Handle both variants in `createHigherOrderTransform` in `DagCompiler`
+5. Add test cases for both plain and closure paths
+6. Update `DagVizCompiler` pattern matches if needed
+
+---
+
+## Component Boundaries
+
+| Component | Closure Responsibility |
+|-----------|----------------------|
+| `core` | Closure transform variants (`InlineTransform.scala`) |
+| `lang-compiler` | Free variable analysis, IR generation (`IRGenerator.scala`) |
+| `lang-compiler` | IR data structures (`IR.scala` — `TypedLambda`, `HigherOrderNode`) |
+| `lang-compiler` | DAG wiring of captured dependencies (`DagCompiler.scala`) |
+| `lang-compiler` | Visualization of HOF nodes (`DagVizCompiler.scala`) |
+
+**Never:**
+- Put free variable analysis in `core` (core is runtime-only, no AST knowledge)
+- Put capture resolution in `lang-parser` (parser produces untyped AST, no scope info)
+- Share node UUIDs between lambda body and outer context (self-containment invariant)
+- Add mutable capture semantics (DAG nodes are immutable by design)
+
+---
+
+## What Is Out of Scope
+
+Do not add:
+
+- **Nested closures.** Capturing through multiple lambda boundaries (lambda inside lambda). Deferred to Phase 3.
+- **Mutable capture.** DAG nodes produce immutable values. No mutable variable capture.
+- **First-class functions.** Lambdas are only valid as HOF arguments (filter, map, all, any). They are not general-purpose values.
+- **Closure serialization.** Closures exist only at compile/execution time. No need to serialize lambda bodies.
+- **Dynamic capture.** All captured variables are determined statically by `collectFreeVars`. No runtime discovery.
+
+---
+
+## Testing Requirements
+
+When modifying closure support:
+
+1. **IR-level tests** for `TypedLambda.capturedBindings` and `HigherOrderNode.capturedInputs`
+2. **DAG-level tests** for `transformInputs` containing captured variable data IDs
+3. **Backwards compatibility tests** confirming non-closure lambdas still use plain transforms
+4. **Shadowing tests** confirming lambda params hide outer variables of the same name
+5. **Multi-capture tests** confirming multiple outer variables can be captured simultaneously
+
+Key test file:
+- `modules/lang-compiler/src/test/scala/io/constellation/lang/compiler/ClosureTest.scala`

--- a/organon/features/lambda-closures/PHILOSOPHY.md
+++ b/organon/features/lambda-closures/PHILOSOPHY.md
@@ -1,0 +1,74 @@
+# Lambda Closures Philosophy
+
+> Why lambdas need to capture variables from their enclosing scope.
+
+---
+
+## The Problem
+
+Without closures, lambda expressions can only reference their own parameters and literals. This prevents common patterns like filtering with a user-provided threshold:
+
+```constellation
+in numbers: List<Int>
+in threshold: Int
+
+# Without closures: FAILS — threshold is not a lambda parameter
+above = filter(numbers, (x) => gt(x, threshold))
+```
+
+Users must work around this by restructuring pipelines to avoid referencing outer variables, which is unnatural and limits expressiveness.
+
+---
+
+## The Bet
+
+Closures are a **fundamental expectation** of any language with lambda expressions. Users coming from Python, JavaScript, Scala, or any modern language expect lambdas to "see" variables in scope. Not supporting this creates friction and confusion.
+
+The bet: the implementation complexity of closures (copy strategy, additional data node wiring) is worth the expressiveness gain.
+
+---
+
+## Design Decisions
+
+### 1. Copy Strategy (Self-Contained Sub-DAGs)
+
+Captured variables become additional `IRNode.Input` nodes copied into the lambda's `bodyNodes` map. The lambda sub-DAG is fully self-contained — no runtime merging of execution contexts.
+
+**Why:** The DAG execution model evaluates nodes by resolving their inputs. By making captured values regular Input nodes in the sub-DAG, the existing mini-interpreter (`evaluateLambdaBodyUnsafe`) handles them without structural changes. The captured values are resolved from `paramBindings` alongside lambda parameters.
+
+### 2. By-Value Capture
+
+Captured variables are resolved from the DAG at execution time, not at lambda definition time. Since DAG node outputs are immutable values, this is equivalent to by-value capture.
+
+**Why:** The DAG model has no concept of mutable references. Each node produces exactly one value. Capturing the node's output is the natural and only option.
+
+### 3. Free Variable Analysis at IR Generation Time
+
+The `collectFreeVars` function pre-scans the lambda body to identify which outer-scope variables are referenced. Only those variables get Input nodes in the sub-DAG.
+
+**Why:** Eager capture (creating Input nodes for all outer variables) would waste resources. Lazy capture (on-demand during expression generation) would require mutable state or a two-pass approach. Pre-scanning is clean, deterministic, and minimal.
+
+### 4. Separate Closure Transform Variants
+
+Closure lambdas use `ClosureFilterTransform`, `ClosureMapTransform`, etc., instead of the plain variants. The closure variants receive `(element, capturedValues)` instead of just `element`.
+
+**Why:** Keeping the non-closure path unchanged preserves backwards compatibility and avoids adding overhead (map lookup for captured values) to lambdas that don't need it.
+
+---
+
+## Trade-Offs
+
+| Decision | Benefit | Cost |
+|----------|---------|------|
+| Copy strategy | Self-contained sub-DAGs, simple runtime | Captured nodes duplicated in IR |
+| By-value capture | Matches DAG immutability model | No mutable capture (intentional) |
+| Pre-scan for free vars | Minimal capture, deterministic | Recursive AST walk |
+| Separate transform variants | No overhead for non-closure lambdas | More InlineTransform subtypes |
+
+---
+
+## What This Does Not Cover
+
+- **Nested closures** (Phase 3): Capturing through multiple lambda boundaries requires transitive capture propagation. Deferred.
+- **Mutable capture**: DAG nodes are immutable. No mutable variable capture by design.
+- **First-class functions**: Lambdas can only be passed to HOF stdlib functions (filter, map, all, any). They are not general-purpose values.

--- a/organon/features/lambda-closures/README.md
+++ b/organon/features/lambda-closures/README.md
@@ -1,0 +1,48 @@
+# Lambda Closures
+
+> **Path**: `organon/features/lambda-closures/`
+> **Parent**: [features/](../README.md)
+
+Lambda expressions that capture variables from their enclosing scope.
+
+## Ethos Summary
+
+- Closures use **by-value capture** (snapshot at lambda creation time)
+- Captured variables become **additional Input nodes** in the lambda sub-DAG (copy strategy)
+- Lambda parameters **shadow** outer variables of the same name
+- **Nested closures** (multi-level capture) are out of scope (deferred to Phase 3)
+
+## Contents
+
+| File | Description |
+|------|-------------|
+| [PHILOSOPHY.md](./PHILOSOPHY.md) | Why closures exist, design reasoning |
+| [ETHOS.md](./ETHOS.md) | Constraints for LLMs working on closures |
+
+## Quick Reference
+
+```constellation
+use stdlib.collection
+use stdlib.compare
+
+in numbers: List<Int>
+in threshold: Int
+
+# Lambda captures `threshold` from outer scope
+above = filter(numbers, (x) => gt(x, threshold))
+out above
+```
+
+## Components Involved
+
+| Component | Role | Key Files |
+|-----------|------|-----------|
+| `lang-compiler` | IR generation with closure capture | `IRGenerator.scala` — `generateLambdaIR`, `collectFreeVars` |
+| `lang-compiler` | IR data structures | `IR.scala` — `TypedLambda.capturedBindings`, `HigherOrderNode.capturedInputs` |
+| `lang-compiler` | DAG compilation with closure wiring | `DagCompiler.scala` — `processHigherOrderNode`, `createClosureEvaluator` |
+| `core` | Closure-aware inline transforms | `InlineTransform.scala` — `ClosureFilterTransform`, `ClosureMapTransform`, etc. |
+
+## See Also
+
+- [rfcs/rfc-030-lambda-closures.md](../../../rfcs/rfc-030-lambda-closures.md) - RFC specification
+- [type-safety/](../type-safety/) - Type checking (already supports closures)

--- a/rfcs/rfc-030-lambda-closures.md
+++ b/rfcs/rfc-030-lambda-closures.md
@@ -1,6 +1,6 @@
 # RFC-030: Lambda Closure Support
 
-- **Status:** Accepted
+- **Status:** Implemented
 - **Created:** 2026-02-15
 - **Author:** Claude (discovered during RFC-029 demo QA)
 


### PR DESCRIPTION
## Summary

- Implement closure support in lambda expressions so lambdas can capture variables from their enclosing scope (RFC-030)
- Uses the **copy strategy**: captured outer nodes are copied into the lambda's sub-DAG as additional `IRNode.Input` nodes, making each lambda self-contained
- Backwards compatible: non-closure lambdas continue to use plain transforms with no overhead

## Changes

### Core Implementation (4 files)
- **`IR.scala`**: Add `capturedBindings` to `TypedLambda`, `capturedInputs` to `HigherOrderNode`, update `dependencies` for topological sort
- **`IRGenerator.scala`**: Free variable analysis via `collectFreeVars` (handles all 17 `TypedExpression` variants), outer context passing to `generateLambdaIR`, fresh `IRNode.Input` creation for captured variables
- **`InlineTransform.scala`**: Closure-aware HOF transforms — `ClosureFilterTransform`, `ClosureMapTransform`, `ClosureAllTransform`, `ClosureAnyTransform`
- **`DagCompiler.scala`**: Captured data ID resolution in `transformInputs`, `createClosureEvaluator` merging param + captured bindings

### Compatibility Updates (3 files)
- **`CommonSubexpressionElimination.scala`**: Pattern match update for new `HigherOrderNode` field
- **`DeadCodeElimination.scala`**: Pattern match update for new `HigherOrderNode` field
- **`DagVizCompiler.scala`**: Pattern match updates + render captured variable edges in visualization

### Tests (2 files)
- **`ClosureTest.scala`** (new): 11 integration tests — basic capture, computed value capture, shadowing, multi-capture, filter/map/all/any closures, IR-level verification, backwards compatibility
- **`PipelineLoaderTest.scala`**: Updated closure tests from failure-expectation to success-expectation

### Documentation (5 files)
- **`rfcs/rfc-030-lambda-closures.md`**: Status updated to Implemented
- **`organon/features/lambda-closures/PHILOSOPHY.md`** (new): Design reasoning — copy strategy, by-value capture, free variable analysis
- **`organon/features/lambda-closures/ETHOS.md`** (new): Behavioral constraints for LLMs working on closures
- **`organon/features/lambda-closures/README.md`** (new): Feature navigation and quick reference
- **`organon/features/README.md`**: Added lambda-closures entry

## Test plan

- [x] ClosureTest: 11/11 pass (basic capture, computed value, shadowing, multi-capture, all 4 HOF ops, IR verification, backwards compat)
- [x] Full lang-compiler suite: 1017 tests pass
- [x] PipelineLoaderTest: 19/19 pass (closure pipelines now load successfully)
- [x] Core module: 357 tests pass
- [ ] Verify no regressions in full `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)