### PR TITLE
feat(http): module HTTP endpoints for direct invocation (RFC-027)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Module HTTP Endpoints** (RFC-027): Opt-in HTTP endpoint publishing for individual modules via `ModuleBuilder.httpEndpoint()`. Adds `GET /modules/published` for discovery and `POST /modules/{name}/invoke` for direct module invocation without writing a `.cst` pipeline
 - **Coursier channel**: `cs channel --add https://vledicfranco.github.io/constellation-engine/channel && cs install constellation` for easy CLI installation
 - **Structural invariant tests**: 12 tests across 4 specs using `organon-testing` v0.4.0 — verifies core purity, organon file structure, naming conventions, and module purity constraints (`make test-invariants`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,7 @@ make test-invariants
 | CORS Middleware | `modules/http-api/.../CorsMiddleware.scala` |
 | Rate Limit Middleware | `modules/http-api/.../RateLimitMiddleware.scala` |
 | Health Check Routes | `modules/http-api/.../HealthCheckRoutes.scala` |
+| Module HTTP Routes | `modules/http-api/.../ModuleHttpRoutes.scala` |
 | LSP Server | `modules/lang-lsp/.../ConstellationLanguageServer.scala` |
 | CLI Entry Point | `modules/lang-cli/.../Main.scala` |
 | CLI App | `modules/lang-cli/.../CliApp.scala` |

--- a/modules/core/src/main/scala/io/constellation/Spec.scala
+++ b/modules/core/src/main/scala/io/constellation/Spec.scala
@@ -116,13 +116,16 @@ final case class DataNodeSpec(
   *   Timeout configuration for inputs and module execution
   * @param definitionContext
   *   Optional JSON metadata from module definition
+  * @param httpConfig
+  *   Optional HTTP endpoint configuration; when present the module is published at `/modules/{name}/invoke`
   */
 case class ModuleNodeSpec(
     metadata: ComponentMetadata,
     consumes: Map[String, CType] = Map.empty,
     produces: Map[String, CType] = Map.empty,
     config: ModuleConfig = ModuleConfig.default,
-    definitionContext: Option[Map[String, Json]] = None
+    definitionContext: Option[Map[String, Json]] = None,
+    httpConfig: Option[ModuleHttpConfig] = None
 ) {
 
   def name: String = metadata.name
@@ -167,6 +170,20 @@ object ModuleConfig {
       inputsTimeout = FiniteDuration(6, "seconds"),
       moduleTimeout = FiniteDuration(3, "seconds")
     )
+}
+
+/** Configuration for publishing a module as an HTTP endpoint.
+  *
+  * When attached to a [[ModuleNodeSpec]], the module becomes callable via `POST
+  * /modules/{name}/invoke` without writing a pipeline.
+  *
+  * @param published
+  *   Whether the endpoint is active (default true)
+  */
+final case class ModuleHttpConfig(published: Boolean = true)
+
+object ModuleHttpConfig {
+  val default: ModuleHttpConfig = ModuleHttpConfig()
 }
 
 /** Shared metadata for components (modules and DAGs).

--- a/modules/http-api/src/main/scala/io/constellation/http/ApiModels.scala
+++ b/modules/http-api/src/main/scala/io/constellation/http/ApiModels.scala
@@ -212,6 +212,59 @@ object ApiModels {
   }
 
   // ---------------------------------------------------------------------------
+  // Module HTTP endpoint models (RFC-027)
+  // ---------------------------------------------------------------------------
+
+  /** Response from invoking a published module directly via HTTP.
+    *
+    * @param success
+    *   Whether the invocation succeeded
+    * @param outputs
+    *   Module output values as JSON (keyed by output field name)
+    * @param error
+    *   Error message if invocation failed
+    * @param module
+    *   Name of the invoked module
+    */
+  case class ModuleInvokeResponse(
+      success: Boolean,
+      outputs: Map[String, Json] = Map.empty,
+      error: Option[String] = None,
+      module: Option[String] = None
+  )
+
+  object ModuleInvokeResponse {
+    given Encoder[ModuleInvokeResponse] = deriveEncoder
+    given Decoder[ModuleInvokeResponse] = deriveDecoder
+  }
+
+  /** Information about a published module endpoint for discovery. */
+  case class PublishedModuleInfo(
+      name: String,
+      description: String,
+      version: String,
+      tags: List[String],
+      endpoint: String,
+      inputs: Map[String, String],
+      outputs: Map[String, String]
+  )
+
+  object PublishedModuleInfo {
+    given Encoder[PublishedModuleInfo] = deriveEncoder
+    given Decoder[PublishedModuleInfo] = deriveDecoder
+  }
+
+  /** Response listing all published module endpoints. */
+  case class PublishedModulesResponse(
+      modules: List[PublishedModuleInfo]
+  )
+
+  object PublishedModulesResponse {
+    given Encoder[PublishedModulesResponse] = deriveEncoder
+    given Decoder[PublishedModulesResponse] = deriveDecoder
+  }
+
+  // ---------------------------------------------------------------------------
   // Pipeline management models (Phase 5)
   // ---------------------------------------------------------------------------
 

--- a/modules/http-api/src/main/scala/io/constellation/http/ConstellationServer.scala
+++ b/modules/http-api/src/main/scala/io/constellation/http/ConstellationServer.scala
@@ -366,6 +366,9 @@ object ConstellationServer {
           canaryRouter = Some(canaryRouter)
         ).routes
 
+        // Module HTTP endpoint routes (RFC-027)
+        moduleHttpRoutes = new ModuleHttpRoutes(effectiveConstellation).routes
+
         server <- EmberServerBuilder
           .default[IO]
           .withHost(host)
@@ -377,7 +380,7 @@ object ConstellationServer {
             // Combine core routes + health routes + optional dashboard routes + WebSocket routes
             // Note: executionWs routes MUST come FIRST because both httpRoutes and dashboardRoutes have
             // catch-all patterns `GET /api/v1/executions/:id` that would match "events" as an ID
-            val coreRoutes = httpRoutes <+> healthRoutes <+> lspHandler.routes(wsb)
+            val coreRoutes = moduleHttpRoutes <+> httpRoutes <+> healthRoutes <+> lspHandler.routes(wsb)
             val withDashboard = dashboardRoutesOpt match {
               case Some(dashboardRoutes) =>
                 executionWs.routes(wsb) <+> dashboardRoutes.routes <+> coreRoutes

--- a/modules/http-api/src/main/scala/io/constellation/http/ModuleHttpRoutes.scala
+++ b/modules/http-api/src/main/scala/io/constellation/http/ModuleHttpRoutes.scala
@@ -1,0 +1,194 @@
+package io.constellation.http
+
+import java.util.UUID
+
+import cats.effect.IO
+import cats.implicits.*
+
+import io.constellation.http.ApiModels.*
+import io.constellation.{
+  CType,
+  CValue,
+  ComponentMetadata,
+  Constellation,
+  DagSpec,
+  DataNodeSpec,
+  JsonCValueConverter,
+  ModuleNodeSpec,
+  Runtime
+}
+
+import io.circe.Json
+import io.circe.syntax.*
+import org.http4s.HttpRoutes
+import org.http4s.circe.CirceEntityCodec.*
+import org.http4s.dsl.io.*
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+/** HTTP routes for direct module invocation and discovery.
+  *
+  * Provides:
+  *   - `GET /modules/published` — list all modules marked with `.httpEndpoint()`
+  *   - `POST /modules/:name/invoke` — invoke a published module with JSON inputs
+  *
+  * Invocation builds a minimal synthetic single-node DAG and delegates to `Runtime.run()`, reusing
+  * all existing execution infrastructure (timeouts, deferred tables, error handling).
+  */
+class ModuleHttpRoutes(constellation: Constellation) {
+
+  private val logger: Logger[IO] = Slf4jLogger.getLoggerFromClass[IO](classOf[ModuleHttpRoutes])
+
+  val routes: HttpRoutes[IO] = HttpRoutes.of[IO] {
+
+    // ===== Discovery =====
+
+    case GET -> Root / "modules" / "published" =>
+      for {
+        specs <- constellation.publishedModules
+        infos = specs.map { spec =>
+          PublishedModuleInfo(
+            name = spec.name,
+            description = spec.description,
+            version = s"${spec.majorVersion}.${spec.minorVersion}",
+            tags = spec.tags,
+            endpoint = s"/modules/${spec.name}/invoke",
+            inputs = spec.consumes.map { case (k, v) => k -> v.toString },
+            outputs = spec.produces.map { case (k, v) => k -> v.toString }
+          )
+        }
+        resp <- Ok(PublishedModulesResponse(infos))
+      } yield resp
+
+    // ===== Invocation =====
+
+    case req @ POST -> Root / "modules" / name / "invoke" =>
+      (for {
+        moduleOpt <- constellation.getModuleByName(name)
+        result <- moduleOpt match {
+          case None =>
+            NotFound(ErrorResponse("NotFound", s"Module '$name' not found"))
+
+          case Some(module) if !module.spec.httpConfig.exists(_.published) =>
+            NotFound(
+              ErrorResponse("NotFound", s"Module '$name' is not published as an HTTP endpoint")
+            )
+
+          case Some(module) =>
+            for {
+              body       <- req.as[Json]
+              jsonInputs <- IO.fromEither(parseJsonInputs(body))
+              cvalues    <- convertInputs(jsonInputs, module.spec)
+              state      <- runSyntheticDag(module.spec, module, cvalues)
+              outputs    <- extractOutputs(state)
+              resp       <- Ok(ModuleInvokeResponse(success = true, outputs = outputs, module = Some(name)))
+            } yield resp
+        }
+      } yield result).handleErrorWith { err =>
+        val message = Option(err.getMessage).getOrElse(err.getClass.getSimpleName)
+        err match {
+          case _: IllegalArgumentException =>
+            BadRequest(
+              ModuleInvokeResponse(success = false, error = Some(message), module = Some(name))
+            )
+          case _ =>
+            logger.error(err)(s"Module invoke failed: $name") *>
+              InternalServerError(
+                ModuleInvokeResponse(success = false, error = Some(message), module = Some(name))
+              )
+        }
+      }
+  }
+
+  /** Parse the request body as a flat JSON object of field → value. */
+  private def parseJsonInputs(body: Json): Either[IllegalArgumentException, Map[String, Json]] =
+    body.asObject match {
+      case Some(obj) => Right(obj.toMap)
+      case None =>
+        Left(new IllegalArgumentException("Request body must be a JSON object"))
+    }
+
+  /** Convert JSON inputs to CValues using the module's consumes schema. */
+  private def convertInputs(
+      jsonInputs: Map[String, Json],
+      spec: ModuleNodeSpec
+  ): IO[Map[String, CValue]] =
+    spec.consumes.toList
+      .traverse { case (fieldName, ctype) =>
+        jsonInputs.get(fieldName) match {
+          case Some(json) =>
+            JsonCValueConverter.jsonToCValue(json, ctype, fieldName) match {
+              case Right(cvalue) => IO.pure(fieldName -> cvalue)
+              case Left(error) =>
+                IO.raiseError(new IllegalArgumentException(s"Input '$fieldName': $error"))
+            }
+          case None =>
+            IO.raiseError(
+              new IllegalArgumentException(s"Missing required input: '$fieldName'")
+            )
+        }
+      }
+      .map(_.toMap)
+
+  /** Build a synthetic single-node DAG and execute it via `Runtime.run()`. */
+  private def runSyntheticDag(
+      spec: ModuleNodeSpec,
+      module: io.constellation.Module.Uninitialized,
+      inputs: Map[String, CValue]
+  ): IO[Runtime.State] = {
+    val moduleId = UUID.randomUUID()
+
+    // Create input data nodes — one per consumes field
+    val inputNodes: Map[UUID, (String, CType)] =
+      spec.consumes.map { case (fieldName, ctype) =>
+        UUID.randomUUID() -> (fieldName, ctype)
+      }
+
+    // Create output data nodes — one per produces field
+    val outputNodes: Map[UUID, (String, CType)] =
+      spec.produces.map { case (fieldName, ctype) =>
+        UUID.randomUUID() -> (fieldName, ctype)
+      }
+
+    // Build data node specs
+    val dataSpecs: Map[UUID, DataNodeSpec] =
+      inputNodes.map { case (uuid, (name, ctype)) =>
+        uuid -> DataNodeSpec(
+          name = name,
+          nicknames = Map(moduleId -> name),
+          cType = ctype
+        )
+      } ++
+        outputNodes.map { case (uuid, (name, ctype)) =>
+          uuid -> DataNodeSpec(
+            name = name,
+            nicknames = Map(moduleId -> name),
+            cType = ctype
+          )
+        }
+
+    // Build edges
+    val inEdges: Set[(UUID, UUID)]  = inputNodes.keySet.map(dataId => (dataId, moduleId))
+    val outEdges: Set[(UUID, UUID)] = outputNodes.keySet.map(dataId => (moduleId, dataId))
+
+    // Build output bindings
+    val outputBindings: Map[String, UUID] =
+      outputNodes.map { case (uuid, (name, _)) => name -> uuid }
+
+    val dagSpec = DagSpec(
+      metadata = ComponentMetadata.empty(s"__invoke_${spec.name}"),
+      modules = Map(moduleId -> spec),
+      data = dataSpecs,
+      inEdges = inEdges,
+      outEdges = outEdges,
+      declaredOutputs = outputNodes.values.map(_._1).toList,
+      outputBindings = outputBindings
+    )
+
+    Runtime.run(dagSpec, inputs, Map(moduleId -> module))
+  }
+
+  /** Extract output CValues from Runtime.State and convert to JSON. */
+  private def extractOutputs(state: Runtime.State): IO[Map[String, Json]] =
+    ExecutionHelper.extractOutputs(state)
+}

--- a/modules/http-api/src/test/scala/io/constellation/http/ModuleHttpRoutesTest.scala
+++ b/modules/http-api/src/test/scala/io/constellation/http/ModuleHttpRoutesTest.scala
@@ -1,0 +1,212 @@
+package io.constellation.http
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.implicits.*
+
+import io.constellation.http.ApiModels.*
+import io.constellation.impl.ConstellationImpl
+import io.constellation.{ModuleBuilder, ModuleHttpConfig}
+
+import io.circe.Json
+import io.circe.syntax.*
+import org.http4s.*
+import org.http4s.circe.CirceEntityCodec.*
+import org.http4s.implicits.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ModuleHttpRoutesTest extends AnyFlatSpec with Matchers {
+
+  // ===== Test module definitions =====
+
+  case class TextInput(text: String)
+  case class TextOutput(result: String)
+
+  case class MathInput(x: Long, y: Long)
+  case class MathOutput(sum: Long)
+
+  private val uppercaseModule = ModuleBuilder
+    .metadata("Uppercase", "Converts text to uppercase", 1, 0)
+    .httpEndpoint()
+    .implementationPure[TextInput, TextOutput](in => TextOutput(in.text.toUpperCase))
+    .build
+
+  private val addModule = ModuleBuilder
+    .metadata("Add", "Adds two numbers", 1, 0)
+    .tags("math")
+    .httpEndpoint()
+    .implementationPure[MathInput, MathOutput](in => MathOutput(in.x + in.y))
+    .build
+
+  private val unpublishedModule = ModuleBuilder
+    .metadata("Secret", "Not published", 1, 0)
+    .implementationPure[TextInput, TextOutput](in => TextOutput(in.text))
+    .build
+
+  private val disabledEndpointModule = ModuleBuilder
+    .metadata("Disabled", "Endpoint disabled", 1, 0)
+    .httpEndpoint(ModuleHttpConfig(published = false))
+    .implementationPure[TextInput, TextOutput](in => TextOutput(in.text))
+    .build
+
+  // ===== Test setup helper =====
+
+  private def setup(
+      modules: List[io.constellation.Module.Uninitialized] = List.empty
+  ): HttpRoutes[IO] = {
+    val constellation = ConstellationImpl.init.unsafeRunSync()
+    modules.foreach(m => constellation.setModule(m).unsafeRunSync())
+    new ModuleHttpRoutes(constellation).routes
+  }
+
+  // ===== GET /modules/published =====
+
+  "GET /modules/published" should "return empty list when no published modules" in {
+    val routes   = setup()
+    val request  = Request[IO](Method.GET, uri"/modules/published")
+    val response = routes.orNotFound.run(request).unsafeRunSync()
+
+    response.status shouldBe Status.Ok
+    val body = response.as[PublishedModulesResponse].unsafeRunSync()
+    body.modules shouldBe empty
+  }
+
+  it should "return only published modules (not unpublished)" in {
+    val routes   = setup(List(uppercaseModule, unpublishedModule))
+    val request  = Request[IO](Method.GET, uri"/modules/published")
+    val response = routes.orNotFound.run(request).unsafeRunSync()
+
+    response.status shouldBe Status.Ok
+    val body = response.as[PublishedModulesResponse].unsafeRunSync()
+    body.modules should have length 1
+    body.modules.head.name shouldBe "Uppercase"
+    body.modules.head.endpoint shouldBe "/modules/Uppercase/invoke"
+  }
+
+  it should "exclude modules with published=false" in {
+    val routes   = setup(List(uppercaseModule, disabledEndpointModule))
+    val request  = Request[IO](Method.GET, uri"/modules/published")
+    val response = routes.orNotFound.run(request).unsafeRunSync()
+
+    response.status shouldBe Status.Ok
+    val body = response.as[PublishedModulesResponse].unsafeRunSync()
+    body.modules should have length 1
+    body.modules.head.name shouldBe "Uppercase"
+  }
+
+  it should "return multiple published modules" in {
+    val routes   = setup(List(uppercaseModule, addModule))
+    val request  = Request[IO](Method.GET, uri"/modules/published")
+    val response = routes.orNotFound.run(request).unsafeRunSync()
+
+    response.status shouldBe Status.Ok
+    val body = response.as[PublishedModulesResponse].unsafeRunSync()
+    body.modules should have length 2
+    body.modules.map(_.name).toSet shouldBe Set("Uppercase", "Add")
+  }
+
+  it should "include input and output schema in module info" in {
+    val routes   = setup(List(addModule))
+    val request  = Request[IO](Method.GET, uri"/modules/published")
+    val response = routes.orNotFound.run(request).unsafeRunSync()
+
+    val body = response.as[PublishedModulesResponse].unsafeRunSync()
+    val info = body.modules.head
+    info.inputs should contain key "x"
+    info.inputs should contain key "y"
+    info.outputs should contain key "sum"
+    info.tags shouldBe List("math")
+    info.version shouldBe "1.0"
+  }
+
+  // ===== POST /modules/:name/invoke =====
+
+  "POST /modules/:name/invoke" should "invoke a published module with correct inputs" in {
+    val routes = setup(List(uppercaseModule))
+    val request = Request[IO](Method.POST, uri"/modules/Uppercase/invoke")
+      .withEntity(Json.obj("text" -> Json.fromString("hello")))
+    val response = routes.orNotFound.run(request).unsafeRunSync()
+
+    response.status shouldBe Status.Ok
+    val body = response.as[ModuleInvokeResponse].unsafeRunSync()
+    body.success shouldBe true
+    body.module shouldBe Some("Uppercase")
+    body.outputs("result") shouldBe Json.fromString("HELLO")
+  }
+
+  it should "invoke a module with multiple inputs" in {
+    val routes = setup(List(addModule))
+    val request = Request[IO](Method.POST, uri"/modules/Add/invoke")
+      .withEntity(Json.obj("x" -> Json.fromInt(3), "y" -> Json.fromInt(7)))
+    val response = routes.orNotFound.run(request).unsafeRunSync()
+
+    response.status shouldBe Status.Ok
+    val body = response.as[ModuleInvokeResponse].unsafeRunSync()
+    body.success shouldBe true
+    body.outputs("sum") shouldBe Json.fromInt(10)
+  }
+
+  it should "return 404 for unknown module" in {
+    val routes = setup(List(uppercaseModule))
+    val request = Request[IO](Method.POST, uri"/modules/Unknown/invoke")
+      .withEntity(Json.obj("text" -> Json.fromString("test")))
+    val response = routes.orNotFound.run(request).unsafeRunSync()
+
+    response.status shouldBe Status.NotFound
+  }
+
+  it should "return 404 for non-published module" in {
+    val routes = setup(List(unpublishedModule))
+    val request = Request[IO](Method.POST, uri"/modules/Secret/invoke")
+      .withEntity(Json.obj("text" -> Json.fromString("test")))
+    val response = routes.orNotFound.run(request).unsafeRunSync()
+
+    response.status shouldBe Status.NotFound
+  }
+
+  it should "return 404 for module with published=false" in {
+    val routes = setup(List(disabledEndpointModule))
+    val request = Request[IO](Method.POST, uri"/modules/Disabled/invoke")
+      .withEntity(Json.obj("text" -> Json.fromString("test")))
+    val response = routes.orNotFound.run(request).unsafeRunSync()
+
+    response.status shouldBe Status.NotFound
+  }
+
+  it should "return 400 for wrong input type" in {
+    val routes = setup(List(addModule))
+    val request = Request[IO](Method.POST, uri"/modules/Add/invoke")
+      .withEntity(Json.obj("x" -> Json.fromString("not-a-number"), "y" -> Json.fromInt(5)))
+    val response = routes.orNotFound.run(request).unsafeRunSync()
+
+    response.status shouldBe Status.BadRequest
+    val body = response.as[ModuleInvokeResponse].unsafeRunSync()
+    body.success shouldBe false
+    body.error shouldBe defined
+  }
+
+  it should "return 400 for missing required field" in {
+    val routes = setup(List(addModule))
+    val request = Request[IO](Method.POST, uri"/modules/Add/invoke")
+      .withEntity(Json.obj("x" -> Json.fromInt(5)))
+    val response = routes.orNotFound.run(request).unsafeRunSync()
+
+    response.status shouldBe Status.BadRequest
+    val body = response.as[ModuleInvokeResponse].unsafeRunSync()
+    body.success shouldBe false
+    body.error.get should include("y")
+  }
+
+  it should "return 400 for non-object body" in {
+    val routes = setup(List(uppercaseModule))
+    val request = Request[IO](Method.POST, uri"/modules/Uppercase/invoke")
+      .withEntity(Json.fromString("not an object"))
+    val response = routes.orNotFound.run(request).unsafeRunSync()
+
+    response.status shouldBe Status.BadRequest
+    val body = response.as[ModuleInvokeResponse].unsafeRunSync()
+    body.success shouldBe false
+    body.error.get should include("JSON object")
+  }
+}

--- a/modules/runtime/src/main/scala/io/constellation/Constellation.scala
+++ b/modules/runtime/src/main/scala/io/constellation/Constellation.scala
@@ -55,6 +55,13 @@ trait Constellation {
     */
   def removeModule(name: String): IO[Unit] = IO.unit
 
+  /** List modules that have been published as HTTP endpoints.
+    *
+    * Returns only modules whose `httpConfig` is defined and `published` is true.
+    */
+  def publishedModules: IO[List[ModuleNodeSpec]] =
+    getModules.map(_.filter(_.httpConfig.exists(_.published)))
+
   // ---------------------------------------------------------------------------
   // New API (Phase 1)
   // ---------------------------------------------------------------------------

--- a/modules/runtime/src/test/scala/io/constellation/ModuleBuilderTest.scala
+++ b/modules/runtime/src/test/scala/io/constellation/ModuleBuilderTest.scala
@@ -160,6 +160,50 @@ class ModuleBuilderTest extends AnyFlatSpec with Matchers {
     )
   }
 
+  // ===== HTTP endpoint configuration =====
+
+  it should "support httpEndpoint on init builder" in {
+    val module = ModuleBuilder
+      .metadata("Published", "A published module", 1, 0)
+      .httpEndpoint()
+      .implementationPure[TestInput, TestOutput](in => TestOutput(in.x + in.y))
+      .build
+
+    module.spec.httpConfig shouldBe Some(ModuleHttpConfig())
+    module.spec.httpConfig.get.published shouldBe true
+  }
+
+  it should "support httpEndpoint with custom config on init builder" in {
+    val config = ModuleHttpConfig(published = false)
+    val module = ModuleBuilder
+      .metadata("CustomHttp", "Custom HTTP config", 1, 0)
+      .httpEndpoint(config)
+      .implementationPure[TestInput, TestOutput](in => TestOutput(in.x))
+      .build
+
+    module.spec.httpConfig shouldBe Some(config)
+    module.spec.httpConfig.get.published shouldBe false
+  }
+
+  it should "have no httpConfig by default" in {
+    val module = ModuleBuilder
+      .metadata("NoHttp", "No HTTP config", 1, 0)
+      .implementationPure[TestInput, TestOutput](in => TestOutput(in.x))
+      .build
+
+    module.spec.httpConfig shouldBe None
+  }
+
+  it should "support httpEndpoint after implementation" in {
+    val module = ModuleBuilder
+      .metadata("PostImpl", "HTTP after impl", 1, 0)
+      .implementationPure[TestInput, TestOutput](in => TestOutput(in.x))
+      .httpEndpoint()
+      .build
+
+    module.spec.httpConfig shouldBe Some(ModuleHttpConfig())
+  }
+
   // ===== Post-implementation builder methods (ModuleBuilder[I, O]) =====
 
   "ModuleBuilder[I, O]" should "support name after implementation" in {

--- a/organon/components/core/ETHOS.md
+++ b/organon/components/core/ETHOS.md
@@ -72,6 +72,7 @@
 | `ModuleNodeSpec` | Specification for a single module node (consumes/produces) |
 | `DataNodeSpec` | Specification for a data node with type and inline transform |
 | `InlineTransform` | Lightweight operation executed directly on data nodes |
+| `ModuleHttpConfig` | Configuration for publishing a module as an HTTP endpoint |
 
 For complete type signatures, see:
 - [io.constellation](/organon/generated/io.constellation.md)

--- a/organon/features/README.md
+++ b/organon/features/README.md
@@ -13,7 +13,7 @@ Feature-driven documentation organized by what Constellation does, not how it's 
 | [resilience/](./resilience/) | Retry, timeout, fallback, cache, throttle, and error handling | compiler, runtime |
 | [parallelization/](./parallelization/) | Automatic concurrent execution of independent modules | runtime |
 | [execution/](./execution/) | Hot, cold, and suspended execution modes | runtime, http-api |
-| [extensibility/](./extensibility/) | SPI for cache, metrics, listeners; module provider protocol for cross-process modules | runtime, module-provider-sdk, module-provider |
+| [extensibility/](./extensibility/) | SPI for cache, metrics, listeners; module provider protocol for cross-process modules; module HTTP endpoints for direct invocation | runtime, module-provider-sdk, module-provider, http-api |
 | [tooling/](./tooling/) | Dashboard, LSP, VSCode extension | http-api, lang-lsp |
 
 ## Structure

--- a/website/docs/api-reference/http-api-overview.md
+++ b/website/docs/api-reference/http-api-overview.md
@@ -73,6 +73,13 @@ All endpoints except `/health`, `/health/live`, `/health/ready`, and `/metrics` 
 | `/pipelines/{name}/canary/rollback` | POST | Rollback canary deployment |
 | `/pipelines/{name}/canary` | DELETE | Abort canary deployment |
 
+### Module HTTP Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/modules/published` | GET | List modules published as HTTP endpoints |
+| `/modules/{name}/invoke` | POST | Invoke a published module directly with JSON inputs |
+
 ---
 
 ## Common Workflows
@@ -111,6 +118,20 @@ PIPELINE_ID=$(curl -s -X POST http://localhost:8080/compile \
 curl -X POST "http://localhost:8080/execute/${PIPELINE_ID}" \
   -H "Content-Type: application/json" \
   -d '{"x": 42}'
+```
+
+### Invoke a Module Directly (No Pipeline)
+
+Use `/modules/{name}/invoke` to call a published module without writing a `.cst` pipeline. First, mark the module with `.httpEndpoint()` in your Scala code.
+
+```bash
+# Discover published modules
+curl http://localhost:8080/modules/published
+
+# Invoke a module directly
+curl -X POST http://localhost:8080/modules/Uppercase/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"text": "hello world"}'
 ```
 
 ### Check Server Health

--- a/website/docs/api-reference/programmatic-api.md
+++ b/website/docs/api-reference/programmatic-api.md
@@ -221,6 +221,28 @@ val module = ModuleBuilder
   .build
 ```
 
+### HTTP Endpoint Publishing
+
+Mark a module as callable via `POST /modules/{name}/invoke` without writing a `.cst` pipeline:
+
+```scala
+val module = ModuleBuilder
+  .metadata("Uppercase", "Convert text to uppercase", 1, 0)
+  .httpEndpoint()  // Published at /modules/Uppercase/invoke
+  .implementationPure[TextInput, TextOutput] { input =>
+    TextOutput(input.text.toUpperCase)
+  }
+  .build
+```
+
+Discover published modules via `GET /modules/published`. Optionally pass a custom config:
+
+```scala
+.httpEndpoint(ModuleHttpConfig(published = false))  // Registered but not published
+```
+
+See the [HTTP API Overview](./http-api-overview) for endpoint details.
+
 ### Configuration
 
 ```scala


### PR DESCRIPTION
## Summary

- Adds opt-in HTTP endpoint publishing for individual modules via `ModuleBuilder.httpEndpoint()`
- `GET /modules/published` discovers all published modules with their input/output schemas
- `POST /modules/{name}/invoke` invokes a module directly with JSON inputs, no `.cst` pipeline needed
- Invocation builds a synthetic single-node DAG and delegates to `Runtime.run()`, reusing all existing execution infrastructure (timeouts, deferred tables, error handling)

## Changes

**Core:**
- `ModuleHttpConfig` case class with `published` flag in `Spec.scala`
- `httpConfig: Option[ModuleHttpConfig]` field on `ModuleNodeSpec`

**Runtime:**
- `.httpEndpoint()` fluent method on `ModuleBuilder` (both init and typed phases)
- `publishedModules` default method on `Constellation` trait

**HTTP API:**
- `ModuleHttpRoutes` — new route handler with discovery and invocation
- `ModuleInvokeResponse`, `PublishedModuleInfo`, `PublishedModulesResponse` API models
- Wired into `ConstellationServer` route composition

**Tests:**
- 13 `ModuleHttpRoutesTest` tests: discovery, invocation, 404/400 errors, `published=false`
- 4 `ModuleBuilderTest` tests: `httpEndpoint()` propagation

**Documentation:**
- Website: `http-api-overview.md`, `programmatic-api.md`, `llm/reference/http-api.md`
- Organon: core and http-api `ETHOS.md`, features `README.md`
- `CLAUDE.md`: file locations table
- `CHANGELOG.md`: unreleased entry

## Test plan

- [x] `httpApi/testOnly ModuleHttpRoutesTest` — 13/13 pass
- [x] `httpApi/test` — 574/574 pass
- [x] `runtime/testOnly ModuleBuilderTest` — 20/20 pass
- [ ] Manual smoke test: `curl /modules/published` and `curl -X POST /modules/Uppercase/invoke`


🤖 Generated with [Claude Code](https://claude.com/claude-code)