### PR TITLE
feat(stream): implement fan-in join strategies — closes #229

### DIFF
--- a/modules/stream/src/main/scala/io/constellation/stream/StreamCompiler.scala
+++ b/modules/stream/src/main/scala/io/constellation/stream/StreamCompiler.scala
@@ -12,6 +12,7 @@ import io.constellation.stream.error.StreamErrorStrategy
 import io.constellation.stream.join.JoinStrategy
 
 import fs2.Stream
+import fs2.concurrent.SignallingRef
 
 /** Compiles a DagSpec into an fs2 Stream graph for continuous execution.
   *
@@ -168,21 +169,23 @@ object StreamCompiler {
       // Get module function
       val moduleFn = modules.get(moduleId)
 
-      // Fan-in guard: warn when multiple inputs are present (fan-in is deferred to a future RFC)
-      if inputDataIds.size > 1 then
-        System.err.println(
-          s"[WARN] StreamCompiler: Module '$moduleName' ($moduleId) has ${inputDataIds.size} inputs; only first used (fan-in is deferred)"
-        )
+      // Build named input streams for fan-in join (field name from DataNodeSpec.name)
+      val namedInputStreams: List[(String, Stream[IO, CValue])] = inputDataIds.toList.flatMap {
+        id =>
+          for {
+            stream   <- streams.get(id)
+            dataSpec <- dagSpec.data.get(id)
+          } yield dataSpec.name -> stream
+      }
+
+      val inputStream: Stream[IO, CValue] = joinInputStreams(namedInputStreams, joinStrategy)
 
       // For each output data node, create a stream that:
-      // 1. Takes input from upstream data nodes
+      // 1. Takes input from upstream data nodes (joined via strategy)
       // 2. Applies the module function
       // 3. Applies error handling
       val newStreams = outputDataIds.flatMap { outDataId =>
         moduleFn.map { fn =>
-          val inputStream = inputDataIds.headOption
-            .flatMap(id => streams.get(id))
-            .getOrElse(Stream.empty)
 
           val processed = errorStrategy match {
             case StreamErrorStrategy.Skip =>
@@ -257,6 +260,75 @@ object StreamCompiler {
 
   private def safeMessage(e: Throwable): String =
     Option(e.getMessage).getOrElse(e.getClass.getSimpleName)
+
+  /** Build a CProduct from a value map, deriving the type structure from each value's ctype. */
+  private def makeCProduct(values: Map[String, CValue]): CValue.CProduct =
+    CValue.CProduct(values, values.map { case (k, v) => k -> v.ctype })
+
+  /** Dispatches to the correct join implementation based on strategy. Single-input passes through
+    * as-is (no CProduct wrapping) — preserves existing single-input behavior exactly.
+    */
+  private def joinInputStreams(
+      namedStreams: List[(String, Stream[IO, CValue])],
+      strategy: JoinStrategy
+  ): Stream[IO, CValue] =
+    namedStreams match {
+      case Nil                => Stream.empty
+      case (_, single) :: Nil => single
+      case multiple =>
+        val names   = multiple.map(_._1)
+        val streams = multiple.map(_._2)
+        strategy match {
+          case JoinStrategy.Zip            => zipAll(names, streams)
+          case JoinStrategy.CombineLatest  => combineLatestAll(multiple)
+          case JoinStrategy.Buffer(maxBuf) => zipAll(names, streams.map(_.buffer(maxBuf)))
+        }
+    }
+
+  /** Zip N streams synchronously into CProduct emissions. Terminates when the shortest stream
+    * terminates (standard zip semantics).
+    */
+  private def zipAll(
+      names: List[String],
+      streams: List[Stream[IO, CValue]]
+  ): Stream[IO, CValue] =
+    streams match {
+      case Nil      => Stream.empty
+      case s :: Nil => s.map(v => makeCProduct(Map(names.head -> v)))
+      case first :: rest =>
+        val zipped = rest.foldLeft(first.map(v => List(v))) { (acc, s) =>
+          acc.zip(s).map { case (vs, v) => vs :+ v }
+        }
+        zipped.map(values => makeCProduct(names.zip(values).toMap))
+    }
+
+  /** CombineLatest: emit a CProduct snapshot whenever any input emits, once all inputs have
+    * produced at least one value. Uses SignallingRef per input to hold latest values; merge
+    * interleaves concurrent input streams without deadlock.
+    */
+  private def combineLatestAll(
+      namedStreams: List[(String, Stream[IO, CValue])]
+  ): Stream[IO, CValue] = {
+    val n = namedStreams.size
+    Stream
+      .eval(namedStreams.traverse { case (name, _) =>
+        SignallingRef.of[IO, Option[CValue]](None).map(name -> _)
+      })
+      .flatMap { refs =>
+        val refMap = refs.toMap
+        namedStreams
+          .map { case (name, stream) =>
+            stream.evalMapFilter { v =>
+              for {
+                _       <- refMap(name).set(Some(v))
+                entries <- refs.traverse { case (n2, ref) => ref.get.map(n2 -> _) }
+                resolved = entries.collect { case (n2, Some(v2)) => n2 -> v2 }
+              } yield Option.when(resolved.size == n)(makeCProduct(resolved.toMap))
+            }
+          }
+          .reduce(_ merge _)
+      }
+  }
 
   /** Topological sort of module nodes in the DAG. */
   private def topologicalSort(dagSpec: DagSpec): List[UUID] = {

--- a/modules/stream/src/test/scala/io/constellation/stream/StreamCompilerTest.scala
+++ b/modules/stream/src/test/scala/io/constellation/stream/StreamCompilerTest.scala
@@ -374,6 +374,172 @@ class StreamCompilerTest extends AnyFlatSpec with Matchers {
     dlq.moduleName shouldBe "mod"
   }
 
+  // ===== Fan-in Join Strategy Tests (Issue #229) =====
+
+  /** Helper to build a fan-in DAG: source1 + source2 -> module -> sink */
+  private def fanInDag(
+      source1Name: String,
+      source2Name: String,
+      moduleName: String,
+      sinkName: String
+  ): (DagSpec, java.util.UUID, java.util.UUID, java.util.UUID) = {
+    val src1Id = java.util.UUID.randomUUID()
+    val src2Id = java.util.UUID.randomUUID()
+    val modId  = java.util.UUID.randomUUID()
+    val snkId  = java.util.UUID.randomUUID()
+
+    val dagSpec = DagSpec(
+      metadata = ComponentMetadata("fan-in", "fan-in pipeline", Nil, 1, 0),
+      modules = Map(
+        modId -> ModuleNodeSpec(
+          metadata = ComponentMetadata(moduleName, "merge", Nil, 1, 0),
+          consumes = Map(source1Name -> CType.CString, source2Name -> CType.CString),
+          produces = Map(
+            "output" -> CType.CProduct(
+              Map(source1Name -> CType.CString, source2Name -> CType.CString)
+            )
+          )
+        )
+      ),
+      data = Map(
+        src1Id -> DataNodeSpec(
+          source1Name,
+          Map(src1Id -> source1Name),
+          CType.CString,
+          None,
+          Map.empty
+        ),
+        src2Id -> DataNodeSpec(
+          source2Name,
+          Map(src2Id -> source2Name),
+          CType.CString,
+          None,
+          Map.empty
+        ),
+        snkId -> DataNodeSpec(
+          sinkName,
+          Map(snkId -> sinkName),
+          CType.CProduct(Map(source1Name -> CType.CString, source2Name -> CType.CString)),
+          None,
+          Map.empty
+        )
+      ),
+      inEdges = Set(src1Id -> modId, src2Id -> modId),
+      outEdges = Set(modId -> snkId),
+      declaredOutputs = List(sinkName),
+      outputBindings = Map(sinkName -> snkId)
+    )
+    (dagSpec, src1Id, src2Id, modId)
+  }
+
+  "StreamCompiler fan-in" should "zip two input streams into CProduct values" in {
+    val (dagSpec, _, _, modId) = fanInDag("left", "right", "Merge", "output")
+
+    val result = (for {
+      q1   <- cats.effect.std.Queue.bounded[IO, Option[CValue]](10)
+      q2   <- cats.effect.std.Queue.bounded[IO, Option[CValue]](10)
+      snkQ <- cats.effect.std.Queue.bounded[IO, CValue](10)
+      registry = ConnectorRegistry.builder
+        .source("left", MemoryConnector.source("left", q1))
+        .source("right", MemoryConnector.source("right", q2))
+        .sink("output", MemoryConnector.sink("output", snkQ))
+        .build
+      identityFn = (v: CValue) => IO.pure(v)
+      graph <- StreamCompiler.wire(
+        dagSpec,
+        registry,
+        Map(modId -> identityFn),
+        joinStrategy = JoinStrategy.Zip
+      )
+      _     <- q1.offer(Some(CValue.CString("a")))
+      _     <- q1.offer(Some(CValue.CString("b")))
+      _     <- q1.offer(Some(CValue.CString("c")))
+      _     <- q1.offer(None)
+      _     <- q2.offer(Some(CValue.CString("x")))
+      _     <- q2.offer(Some(CValue.CString("y")))
+      _     <- q2.offer(Some(CValue.CString("z")))
+      _     <- q2.offer(None)
+      _     <- graph.stream.compile.drain
+      items <- snkQ.tryTakeN(None)
+    } yield items).unsafeRunSync()
+
+    result should have size 3
+    all(result) shouldBe a[CValue.CProduct]
+    result(0).asInstanceOf[CValue.CProduct].value("left") shouldBe CValue.CString("a")
+    result(0).asInstanceOf[CValue.CProduct].value("right") shouldBe CValue.CString("x")
+    result(2).asInstanceOf[CValue.CProduct].value("left") shouldBe CValue.CString("c")
+    result(2).asInstanceOf[CValue.CProduct].value("right") shouldBe CValue.CString("z")
+  }
+
+  it should "combineLatest two input streams into CProduct values" in {
+    val (dagSpec, _, _, modId) = fanInDag("left", "right", "Merge", "output")
+
+    val result = (for {
+      q1   <- cats.effect.std.Queue.bounded[IO, Option[CValue]](10)
+      q2   <- cats.effect.std.Queue.bounded[IO, Option[CValue]](10)
+      snkQ <- cats.effect.std.Queue.bounded[IO, CValue](10)
+      registry = ConnectorRegistry.builder
+        .source("left", MemoryConnector.source("left", q1))
+        .source("right", MemoryConnector.source("right", q2))
+        .sink("output", MemoryConnector.sink("output", snkQ))
+        .build
+      identityFn = (v: CValue) => IO.pure(v)
+      graph <- StreamCompiler.wire(
+        dagSpec,
+        registry,
+        Map(modId -> identityFn),
+        joinStrategy = JoinStrategy.CombineLatest
+      )
+      _     <- q1.offer(Some(CValue.CString("a")))
+      _     <- q1.offer(None)
+      _     <- q2.offer(Some(CValue.CString("x")))
+      _     <- q2.offer(None)
+      _     <- graph.stream.compile.drain
+      items <- snkQ.tryTakeN(None)
+    } yield items).unsafeRunSync()
+
+    result should not be empty
+    all(result) shouldBe a[CValue.CProduct]
+    result.foreach { v =>
+      val m = v.asInstanceOf[CValue.CProduct].value
+      m should contain key "left"
+      m should contain key "right"
+    }
+  }
+
+  it should "buffer two input streams and zip into CProduct values" in {
+    val (dagSpec, _, _, modId) = fanInDag("left", "right", "Merge", "output")
+
+    val result = (for {
+      q1   <- cats.effect.std.Queue.bounded[IO, Option[CValue]](10)
+      q2   <- cats.effect.std.Queue.bounded[IO, Option[CValue]](10)
+      snkQ <- cats.effect.std.Queue.bounded[IO, CValue](10)
+      registry = ConnectorRegistry.builder
+        .source("left", MemoryConnector.source("left", q1))
+        .source("right", MemoryConnector.source("right", q2))
+        .sink("output", MemoryConnector.sink("output", snkQ))
+        .build
+      identityFn = (v: CValue) => IO.pure(v)
+      graph <- StreamCompiler.wire(
+        dagSpec,
+        registry,
+        Map(modId -> identityFn),
+        joinStrategy = JoinStrategy.Buffer(16)
+      )
+      _     <- q1.offer(Some(CValue.CString("a")))
+      _     <- q1.offer(Some(CValue.CString("b")))
+      _     <- q1.offer(None)
+      _     <- q2.offer(Some(CValue.CString("x")))
+      _     <- q2.offer(Some(CValue.CString("y")))
+      _     <- q2.offer(None)
+      _     <- graph.stream.compile.drain
+      items <- snkQ.tryTakeN(None)
+    } yield items).unsafeRunSync()
+
+    result should have size 2
+    all(result) shouldBe a[CValue.CProduct]
+  }
+
   "MemoryConnector.pair" should "create matched source/sink pair" in {
     val result = (for {
       pairResult <- MemoryConnector.pair("test-pair")

--- a/rfcs/rfc-025-streaming-pipelines.md
+++ b/rfcs/rfc-025-streaming-pipelines.md
@@ -1,6 +1,6 @@
 # RFC-025: Streaming Pipelines
 
-**Status:** Implemented (Beta)
+**Status:** Implemented
 **Priority:** P1 (Core Runtime / Extensibility)
 **Author:** Human + Claude
 **Created:** 2026-02-10
@@ -1339,7 +1339,7 @@ Targeted tests for specific risks identified in the PR:
 | `filter(list, pred)` where `list: List<Int>` | HOF `List→Seq` breakage | Type error (confirms regression) |
 | `filter(seq, pred)` where `seq: Seq<Int>` | HOF works with new type | Should compile and run |
 | `with on_error: skip` on non-String module | Skip strategy emits `CString("")` | Wrong type downstream (confirms bug) |
-| DAG with 2 inputs to single module | Fan-in not implemented | Should error clearly, not silently drop |
+| DAG with 2 inputs to single module | Fan-in implemented (#229) | Joins via Zip/CombineLatest/Buffer → CProduct |
 | `with window: tumbling(5s)` at runtime | Windowing not applied in `StreamCompiler` | Verify: silent ignore or explicit error? |
 
 #### Phase 4: Document Results and Update Golden Outputs
@@ -1360,8 +1360,8 @@ Targeted tests for specific risks identified in the PR:
 | `with window:` / `with batch:` options | **Implemented** | Parser supports; `StreamCompiler` applies window/batch options |
 | Graceful shutdown | **Fixed** | `Deferred`-based `interruptWhen` wired into composed stream |
 | Error message in `StreamStatus.Failed` | **Fixed** | Was silently discarding error string |
-| Fan-in (multiple upstream inputs) | **Deferred** | Raises warning; only first input used. See [P1] issue |
-| Join strategies (zip, combineLatest, buffer) | **Deferred** | Parsed but not applied by `StreamCompiler` |
+| Fan-in (multiple upstream inputs) | **Implemented** | `joinInputStreams` dispatches Zip/CombineLatest/Buffer. Closes #229 |
+| Join strategies (zip, combineLatest, buffer) | **Implemented** | Applied by `StreamCompiler.buildGraph` via `joinInputStreams` |
 | `collect` pseudo-module | **Deferred** | Not implemented — auto-materialization boundary |
 | `CType.CSeq` in type system | **Deferred** | `CValue.CSeq` exists; `CType.CSeq` is a separate RFC scope |
 | Circuit breaker | **Deferred** | Phase 5 RFC — requires own design doc |


### PR DESCRIPTION
## Summary

- Replace the `headOption` stub in `StreamCompiler.buildGraph` that silently dropped all inputs except the first for multi-input streaming modules
- Implement all three `JoinStrategy` variants: **Zip** (synchronized N-way zip → CProduct), **CombineLatest** (SignallingRef-based latest-value snapshots), **Buffer(n)** (buffered zip for rate smoothing)
- Single-input path unchanged — raw CValue passthrough, no wrapping
- Promote RFC-025 from `Implemented (Beta)` to `Implemented`

## What changed

| File | Change |
|------|--------|
| `StreamCompiler.scala` | Replace warn+headOption with `joinInputStreams` dispatch + 3 private helpers (`zipAll`, `combineLatestAll`, `makeCProduct`) |
| `StreamCompilerTest.scala` | Add `fanInDag` helper + 3 integration tests (Zip, CombineLatest, Buffer) |
| `rfc-025-streaming-pipelines.md` | Status → `Implemented`, fan-in/join rows updated |

## Test plan

- [x] `sbt stream/test` — 100 tests pass (3 new fan-in + 97 existing, no regressions)
- [x] `make test` — full suite green (1079 compiler + 228 example-app + 100 stream)
- [x] `sbt stream/scalafmtCheck` — formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)