### PR TITLE
docs(rfcs): Phase 5 — circuit breaker, delivery guarantees, stateful streaming

### DIFF
--- a/rfcs/rfc-035-stream-circuit-breaker.md
+++ b/rfcs/rfc-035-stream-circuit-breaker.md
@@ -1,0 +1,232 @@
+# RFC-035: Stream-Level Circuit Breaker
+
+**Status:** Draft
+**Priority:** P1 (Streaming Reliability)
+**Author:** Francisco + Claude
+**Created:** 2026-02-22
+**Depends on:** RFC-025 (Streaming Pipelines)
+**Splits from:** RFC-025 Phase 5, Issue #231
+
+---
+
+## Summary
+
+Add a **stream-level circuit breaker** that pauses source consumption when consecutive element failures exceed a configurable threshold. This protects downstream systems from poisoned streams and prevents DLQ flooding, while allowing automatic recovery through a half-open probe mechanism.
+
+The existing `CircuitBreaker` in `runtime/execution/` protects **individual module calls** (per-invocation). This RFC introduces a **per-stream** circuit breaker that operates at the pipeline level — pausing the entire source when the stream is unhealthy, rather than rejecting individual operations.
+
+---
+
+## Motivation
+
+### The Problem
+
+A streaming pipeline processing events from an external source (Kafka, WebSocket, HTTP SSE) can encounter sustained failure modes:
+
+- **Poisoned partition:** A batch of malformed events causes every module invocation to fail
+- **Downstream outage:** A sink's backing service goes down, causing all writes to fail
+- **Resource exhaustion:** Memory pressure or connection pool saturation causes cascading failures
+
+Without a circuit breaker, the stream continues pulling events, failing on each one, and routing them to the DLQ. At 1,000 events/sec with a sustained failure, the DLQ receives 1,000 poison records per second — compounding the problem instead of containing it.
+
+### Current State
+
+| Component | Exists | Scope |
+|-----------|--------|-------|
+| `CircuitBreaker` trait | Yes (`runtime/execution/`) | Per-module-invocation, request-response mode |
+| `CircuitBreakerRegistry` | Yes (`runtime/execution/`) | Creates per-module-name breakers for `Runtime.runWithBackends` |
+| `StreamEvent.CircuitOpen` | Yes (`stream/StreamEvent.scala`) | Event type defined but never emitted |
+| `StreamEvent.CircuitClosed` | Yes (`stream/StreamEvent.scala`) | Event type defined but never emitted |
+| `StreamOptions.maxConsecutiveErrors` | No | Referenced in RFC-025 spec but not in current `StreamOptions` |
+| Stream-level pause/resume | No | Not implemented |
+
+The event types exist. The runtime circuit breaker exists. What's missing is the **stream-level orchestration** that connects them.
+
+### What This Enables
+
+- Streams **self-heal** — pause on sustained failure, probe periodically, resume when healthy
+- DLQ stays manageable — bounded error volume during outages
+- Dashboard shows circuit state — operators see which streams are paused and why
+- Configurable per-pipeline — different thresholds for different risk profiles
+
+---
+
+## Design
+
+### Stream Circuit Breaker State Machine
+
+```
+         success
+    ┌────────────────┐
+    │                │
+    ▼     failure    │
+ CLOSED ──────────► OPEN ──────────► HALF_OPEN
+    ▲   (threshold)   │  (cooldown)      │
+    │                 │                  │
+    │                 │     failure      │
+    │                 ◄──────────────────┘
+    │                   (double cooldown)
+    │                 │
+    │     success     │
+    └─────────────────┘
+      (from HALF_OPEN)
+```
+
+**States:**
+
+| State | Behavior |
+|-------|----------|
+| `Closed` | Normal operation. Elements flow through the pipeline. Consecutive failure counter increments on error, resets on success. |
+| `Open` | Stream paused — source stops pulling. `StreamEvent.CircuitOpen` emitted. Cooldown timer starts. |
+| `HalfOpen` | After cooldown expires, pull exactly one element (probe). If it succeeds → `Closed`. If it fails → `Open` with doubled cooldown (capped at `maxCooldown`). |
+
+### Configuration
+
+Extend `StreamOptions` with circuit breaker settings:
+
+```scala
+case class StreamOptions(
+  // ... existing fields ...
+  defaultParallelism: Int = 1,
+  defaultBufferSize: Int = 256,
+  shutdownTimeout: FiniteDuration = 30.seconds,
+  metricsEnabled: Boolean = true,
+
+  // Circuit breaker (new)
+  circuitBreakerEnabled: Boolean = true,
+  consecutiveFailureThreshold: Int = 100,
+  initialCooldown: FiniteDuration = 30.seconds,
+  maxCooldown: FiniteDuration = 5.minutes,
+  cooldownMultiplier: Double = 2.0
+)
+```
+
+### New Type: `StreamCircuitBreaker`
+
+```scala
+// modules/stream/src/main/scala/io/constellation/stream/circuit/StreamCircuitBreaker.scala
+
+sealed trait StreamCircuitState
+object StreamCircuitState {
+  case object Closed                                    extends StreamCircuitState
+  case class Open(since: Instant, cooldown: FiniteDuration) extends StreamCircuitState
+  case object HalfOpen                                  extends StreamCircuitState
+}
+
+trait StreamCircuitBreaker {
+  def state: IO[StreamCircuitState]
+  def recordSuccess: IO[Unit]
+  def recordFailure: IO[Unit]
+  def shouldPull: IO[Boolean]   // false when Open (and cooldown not expired)
+  def stats: IO[StreamCircuitStats]
+}
+
+case class StreamCircuitStats(
+  consecutiveFailures: Long,
+  totalOpens: Long,
+  totalProbes: Long,
+  lastOpenedAt: Option[Instant],
+  currentCooldown: FiniteDuration
+)
+```
+
+### Integration Point: `StreamCompiler`
+
+The circuit breaker wraps the **source pull**, not individual module calls. In `StreamCompiler.wire()`:
+
+```
+source.stream(config)
+  .through(circuitBreakerGate)   // <-- new: gate that pauses when open
+  .through(modulePipeline)
+  .through(errorHandler)
+  .through(sink.pipe(config))
+```
+
+The `circuitBreakerGate` is an fs2 `Pipe` that:
+
+1. **Closed:** passes elements through, calls `recordSuccess`/`recordFailure` based on downstream outcome
+2. **Open:** emits nothing (blocks the pull), polls `shouldPull` on a timer
+3. **HalfOpen:** passes exactly one element, transitions based on result
+
+The feedback loop requires the circuit breaker to observe **downstream** results. This means the breaker wraps the entire `modulePipeline + errorHandler` stage, not just the source:
+
+```scala
+def withCircuitBreaker(
+    breaker: StreamCircuitBreaker,
+    eventSink: StreamEvent => IO[Unit]
+)(inner: Pipe[IO, CValue, CValue]): Pipe[IO, CValue, CValue] =
+  source => source.through(inner).evalTap { _ =>
+    breaker.recordSuccess
+  }.handleErrorWith { error =>
+    Stream.exec(breaker.recordFailure) ++
+      Stream.exec(eventSink(StreamEvent.CircuitOpen(...)))
+  }
+```
+
+The actual implementation is more nuanced (per-element error observation vs stream-level errors), but the principle is: **observe outcomes after module execution, gate before source pull**.
+
+### Event Emission
+
+The existing `StreamEvent.CircuitOpen` and `StreamEvent.CircuitClosed` types are already defined. The circuit breaker emits these through the stream's event callback (passed via `StreamCompiler.wire`).
+
+### Dashboard Integration
+
+No dashboard changes required in this RFC. The `StreamEvent` types are already part of the metrics pipeline — once emitted, they'll appear in stream metrics and the `/api/v1/streams/:id/metrics` endpoint. A follow-up could add visual indicators to the dashboard.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Core `StreamCircuitBreaker` (~200 LOC)
+
+- [ ] Create `modules/stream/src/main/scala/io/constellation/stream/circuit/StreamCircuitBreaker.scala`
+- [ ] Implement `Ref`-based state machine: `Closed → Open → HalfOpen → Closed`
+- [ ] Implement cooldown with exponential backoff (capped at `maxCooldown`)
+- [ ] Unit tests for state transitions, cooldown doubling, reset on success
+
+### Phase 2: `StreamOptions` Extension + Wiring (~150 LOC)
+
+- [ ] Add circuit breaker fields to `StreamOptions`
+- [ ] Create `circuitBreakerGate` pipe in `StreamCompiler`
+- [ ] Wire into `StreamCompiler.wire()` / `StreamCompiler.wireWithConfig()`
+- [ ] Emit `StreamEvent.CircuitOpen` / `StreamEvent.CircuitClosed` at transitions
+
+### Phase 3: Integration Tests (~200 LOC)
+
+- [ ] Test: stream pauses after N consecutive failures
+- [ ] Test: stream resumes after cooldown + successful probe
+- [ ] Test: cooldown doubles on probe failure (up to max)
+- [ ] Test: success resets consecutive failure counter
+- [ ] Test: circuit breaker disabled when `circuitBreakerEnabled = false`
+- [ ] Test: metrics reflect circuit state transitions
+
+### Phase 4: HTTP API Surface (~50 LOC)
+
+- [ ] Expose circuit breaker state in `/api/v1/streams/:id` response
+- [ ] Add `circuitState` field to `StreamInfoResponse` (open/closed/half-open)
+
+---
+
+## Alternatives Considered
+
+### Reuse the existing `CircuitBreaker` from `runtime/execution/`
+
+Rejected. The runtime circuit breaker protects individual `IO[A]` operations — it throws `CircuitOpenException` when open. Stream-level circuit breaking needs to **pause the source pull**, which is a fundamentally different mechanism (fs2 backpressure vs exception throwing). The state machine logic is similar but the integration surface is different.
+
+### Per-module circuit breakers within the stream
+
+The runtime already supports this via `CircuitBreakerRegistry` in `Runtime.runWithBackends`. Per-module breakers are orthogonal to the stream-level breaker proposed here — they protect individual modules from repeated failures, while the stream-level breaker protects the **entire pipeline** from sustained failure cascades. Both can coexist.
+
+### Kill the stream instead of pausing
+
+Rejected. Killing requires manual restart. Pausing with auto-recovery is operationally superior — the stream self-heals when the underlying issue resolves.
+
+---
+
+## Open Questions
+
+1. **Should the circuit breaker count DLQ-routed elements as failures?** If `on_error: dlq` routes an element to the DLQ, that's "handled" from the stream's perspective. But if 100% of elements go to DLQ, the stream is still unhealthy. Proposed: DLQ counts as failure for circuit breaker purposes.
+
+2. **Per-branch circuit breakers in fan-out?** RFC-025 says "each branch has independent error handling." Should each branch get its own circuit breaker, or should one global breaker cover the entire stream? Proposed: start with one per stream, add per-branch in a follow-up if needed.
+
+3. **Should the circuit breaker be exposed in the constellation-lang `with` clause?** E.g., `with { circuit_breaker: { threshold: 50, cooldown: 10s } }`. Proposed: defer to deployment config for now; language support is a separate enhancement.

--- a/rfcs/rfc-036-delivery-guarantees.md
+++ b/rfcs/rfc-036-delivery-guarantees.md
@@ -1,0 +1,298 @@
+# RFC-036: Streaming Delivery Guarantees
+
+**Status:** Draft
+**Priority:** P1 (Streaming Reliability)
+**Author:** Francisco + Claude
+**Created:** 2026-02-22
+**Depends on:** RFC-025 (Streaming Pipelines), RFC-035 (Stream Circuit Breaker)
+**Splits from:** RFC-025 Phase 5, Issue #231
+
+---
+
+## Summary
+
+Formalize and complete the **delivery guarantee** system for streaming pipelines. RFC-025 defined three guarantee levels (at-most-once, at-least-once, exactly-once) and partially implemented the first two. This RFC:
+
+1. **Hardens at-least-once** — closes gaps in the current offset commit protocol (per-element vs batched commits, fan-out acknowledgment, failure replay)
+2. **Introduces exactly-once** — defines a transactional connector SPI and a two-phase commit protocol for source-to-sink atomic delivery
+3. **Adds deployment-time validation** — the system rejects pipeline configurations that claim a guarantee level their connectors can't support
+
+---
+
+## Motivation
+
+### Current State
+
+| Guarantee | Defined | Implemented | Gaps |
+|-----------|---------|-------------|------|
+| **At-most-once** | Yes | Yes | None — fire-and-forget is the default, works correctly |
+| **At-least-once** | Yes | Partial | Offset commit exists (`OffsetCommitter`) but is not wired into `StreamCompiler`. No connector implements it. No fan-out coordination. |
+| **Exactly-once** | Yes (spec) | No | Not started. Requires transactional SPI. |
+
+The `DeliveryGuarantee` enum, `OffsetCommitter` trait, and `Offset` type exist in `modules/stream/src/main/scala/io/constellation/stream/delivery/`. But the `StreamCompiler` never calls `offsetCommitter.commit()` — offsets are defined but not committed.
+
+### What This Enables
+
+- **At-least-once:** On pipeline restart, the source replays from the last committed offset. No data loss. Elements may be reprocessed (modules should be idempotent or duplicate-tolerant).
+- **Exactly-once:** For compatible connector pairs (e.g., Kafka → Kafka), each element is processed and delivered exactly once, even across restarts. This is the gold standard for financial transactions, inventory updates, and other non-idempotent workloads.
+- **Deployment validation:** `exactly_once: true` on a pipeline with a memory source fails at deploy time with a clear error, rather than silently degrading.
+
+---
+
+## Design
+
+### Delivery Guarantee Levels
+
+```
+At-Most-Once          At-Least-Once              Exactly-Once
+─────────────         ─────────────              ────────────
+source.pull()         source.pull()              txn.begin()
+  │                     │  (no commit yet)         source.pull()
+  ▼                     ▼                            │
+process(elem)         process(elem)              process(elem)
+  │                     │                            │
+  ▼                     ▼                            ▼
+sink.write(result)    sink.write(result)          sink.write(result)  ← transactional
+  │                     │                            │
+  done                  ▼                            ▼
+                      source.commit(offset)       txn.commit()        ← atomic
+                        │                            │
+                        done                         done
+```
+
+### Part 1: Hardening At-Least-Once
+
+#### Offset Embedding
+
+The current `OffsetCommitter` has `commit(offset: Offset)` but no mechanism to associate an offset with a specific element. The source connector must embed offset metadata:
+
+```scala
+// Extend SourceConnector with offset-aware streaming
+trait OffsetAwareSource extends SourceConnector {
+  def streamWithOffsets(config: ValidatedConnectorConfig): Stream[IO, (CValue, Offset)]
+  override def deliveryGuarantee: DeliveryGuarantee = DeliveryGuarantee.AtLeastOnce
+}
+```
+
+For sources that don't support offsets, the default `stream()` method continues to work with `AtMostOnce` semantics.
+
+#### Commit Strategy
+
+Not every element should trigger an offset commit — that would be prohibitively expensive for high-throughput sources. Three strategies:
+
+| Strategy | Behavior | Use Case |
+|----------|----------|----------|
+| `PerElement` | Commit after every element | Low-throughput, maximum safety |
+| `Interval(duration)` | Commit on a timer (e.g., every 5s) | Default — good balance |
+| `Count(n)` | Commit every N elements | Batch-oriented workloads |
+
+```scala
+sealed trait CommitStrategy
+object CommitStrategy {
+  case object PerElement                       extends CommitStrategy
+  case class Interval(every: FiniteDuration)   extends CommitStrategy
+  case class Count(every: Int)                 extends CommitStrategy
+}
+```
+
+Default: `Interval(5.seconds)`.
+
+#### Fan-Out Coordination
+
+RFC-025 states: "Write to ALL sinks (fan-out: wait for every branch)." For at-least-once, the offset must only be committed after **all** sink branches have confirmed the element. This requires:
+
+1. A `Deferred` per element that completes when all sink branches have written
+2. A background fiber that commits offsets as their corresponding Deferreds complete
+3. Ordering guarantee: offsets commit in sequence (no gaps)
+
+```
+source.pull() → elem(offset=42)
+  ├─► branch A: sink_a.write(result_a) → ack_a
+  └─► branch B: sink_b.write(result_b) → ack_b
+                                           │
+  (ack_a AND ack_b) ──────────────────────►commit(offset=42)
+```
+
+#### Wiring into StreamCompiler
+
+`StreamCompiler.wire()` gains a `commitStrategy` parameter. When the source is `OffsetAwareSource` and delivery is `AtLeastOnce`:
+
+1. Use `streamWithOffsets()` instead of `stream()`
+2. After the module pipeline and all sink branches complete per element, commit the offset
+3. On pipeline restart, the source resumes from `offsetCommitter.currentOffset()`
+
+### Part 2: Exactly-Once via Transactional SPI
+
+#### Transactional Connector Traits
+
+```scala
+trait TransactionalSource extends SourceConnector {
+  def deliveryGuarantee: DeliveryGuarantee = DeliveryGuarantee.ExactlyOnce
+  def beginTransaction: IO[SourceTransaction]
+}
+
+trait SourceTransaction {
+  def pull: Stream[IO, (CValue, Offset)]
+  def commit: IO[Unit]
+  def abort: IO[Unit]
+}
+
+trait TransactionalSink extends SinkConnector {
+  def beginTransaction: IO[SinkTransaction]
+}
+
+trait SinkTransaction {
+  def write(value: CValue): IO[Unit]
+  def commit: IO[Unit]
+  def abort: IO[Unit]
+}
+```
+
+#### Two-Phase Commit Protocol
+
+For `ExactlyOnce` pipelines:
+
+```
+1. source_txn = source.beginTransaction()
+2. sink_txn   = sink.beginTransaction()       // one per sink branch
+3. element    = source_txn.pull()
+4. result     = process(element)
+5. sink_txn.write(result)                      // for each sink
+6. sink_txn.commit()                           // Phase 1: sinks commit
+7. source_txn.commit()                         // Phase 2: source commits
+```
+
+If step 4 or 5 fails:
+```
+sink_txn.abort()
+source_txn.abort()
+→ element will be re-pulled on next transaction
+```
+
+If step 6 fails (sink commit):
+```
+source_txn.abort()
+→ element will be re-pulled; sink's failed commit means nothing was written
+```
+
+If step 7 fails (source commit after sink committed):
+```
+→ element was written to sink but source offset not committed
+→ on restart, element is re-pulled and re-processed
+→ sink must be IDEMPOTENT or use deduplication (e.g., Kafka producer idempotence)
+```
+
+This is the standard "at-least-once with idempotent sinks" pattern that systems like Kafka Streams use to achieve effectively-exactly-once semantics.
+
+#### Deployment Validation
+
+When a pipeline is deployed with `exactly_once: true`:
+
+```scala
+def validateDeliveryGuarantee(
+    sources: Map[String, SourceConnector],
+    sinks: Map[String, SinkConnector],
+    requested: DeliveryGuarantee
+): Either[String, Unit] = requested match {
+  case DeliveryGuarantee.ExactlyOnce =>
+    val nonTransactionalSources = sources.filterNot(_._2.isInstanceOf[TransactionalSource])
+    val nonTransactionalSinks   = sinks.filterNot(_._2.isInstanceOf[TransactionalSink])
+    if (nonTransactionalSources.nonEmpty || nonTransactionalSinks.nonEmpty)
+      Left(s"Exactly-once requires transactional connectors. " +
+           s"Non-transactional sources: ${nonTransactionalSources.keys.mkString(", ")}. " +
+           s"Non-transactional sinks: ${nonTransactionalSinks.keys.mkString(", ")}.")
+    else Right(())
+  case _ => Right(())
+}
+```
+
+This runs at deploy time (`StreamRoutes.deployStream`) and returns a `400 Bad Request` if the connectors don't support the requested guarantee.
+
+### Part 3: Extend `DeliveryGuarantee` Enum
+
+```scala
+sealed trait DeliveryGuarantee
+object DeliveryGuarantee {
+  case object AtMostOnce  extends DeliveryGuarantee
+  case object AtLeastOnce extends DeliveryGuarantee
+  case object ExactlyOnce extends DeliveryGuarantee
+}
+```
+
+### Configuration Surface
+
+Delivery guarantees are set per pipeline at deployment time:
+
+```json
+POST /api/v1/streams
+{
+  "pipelineRef": "my-pipeline",
+  "sourceBindings": { ... },
+  "sinkBindings": { ... },
+  "options": {
+    "deliveryGuarantee": "at-least-once",
+    "commitStrategy": "interval",
+    "commitInterval": "5s"
+  }
+}
+```
+
+---
+
+## Implementation Plan
+
+### Phase 1: Harden At-Least-Once (~300 LOC)
+
+- [ ] Add `OffsetAwareSource` trait extending `SourceConnector`
+- [ ] Add `CommitStrategy` enum to `StreamOptions`
+- [ ] Wire offset commit into `StreamCompiler` — commit after sink confirmation
+- [ ] Implement batched commit (interval-based, default 5s)
+- [ ] Add `deliveryGuarantee` field to `StreamDeployRequest`
+- [ ] Unit tests: offset commit after processing, replay on restart
+
+### Phase 2: Exactly-Once SPI (~250 LOC)
+
+- [ ] Add `ExactlyOnce` to `DeliveryGuarantee` enum
+- [ ] Define `TransactionalSource` and `TransactionalSink` traits
+- [ ] Define `SourceTransaction` and `SinkTransaction` traits
+- [ ] Implement two-phase commit orchestration in `StreamCompiler`
+- [ ] Add deployment-time validation (reject incompatible connectors)
+- [ ] Unit tests with mock transactional connectors
+
+### Phase 3: Fan-Out Acknowledgment (~200 LOC)
+
+- [ ] Implement per-element `Deferred`-based acknowledgment for multi-sink pipelines
+- [ ] Ensure offset commits are ordered (no gaps)
+- [ ] Integration test: fan-out with at-least-once, verify all branches ack before commit
+
+### Phase 4: Memory Connector Reference Implementation (~100 LOC)
+
+- [ ] Implement `OffsetAwareMemorySource` (for testing at-least-once)
+- [ ] Implement `TransactionalMemorySource` / `TransactionalMemorySink` (for testing exactly-once)
+- [ ] These are test-only implementations — real connectors (Kafka) come in separate RFCs
+
+---
+
+## Alternatives Considered
+
+### Exactly-once via distributed transactions (2PC with coordinator)
+
+Rejected for initial implementation. A full two-phase commit with a separate transaction coordinator adds significant complexity (coordinator availability, timeout handling, participant recovery). The Kafka-style approach (at-least-once + idempotent sinks) achieves effectively-exactly-once with much simpler machinery. A future RFC could add coordinator-based 2PC for heterogeneous source/sink pairs.
+
+### Offset tracking inside CValue
+
+One approach is to embed offset metadata inside each `CValue` as it flows through the pipeline. Rejected — this leaks transport concerns into the domain model. Offsets are tracked in a parallel channel alongside the main data stream.
+
+### Library-level exactly-once (e.g., fs2-kafka transactions)
+
+For Kafka-to-Kafka pipelines, fs2-kafka provides built-in transactional semantics. The connector SPI proposed here is intentionally more abstract — it supports Kafka but also other transactional systems. The Kafka connector RFC will use fs2-kafka's transactional APIs internally while conforming to the `TransactionalSource`/`TransactionalSink` SPI.
+
+---
+
+## Open Questions
+
+1. **Should `AtLeastOnce` be the default for persistent connectors?** Currently `AtMostOnce` is the universal default. Changing the default for persistent sources would be safer but might surprise users with unexpected replay behavior. Proposed: keep `AtMostOnce` as default everywhere, require explicit opt-in.
+
+2. **How should exactly-once interact with the circuit breaker (RFC-035)?** When the circuit opens, in-flight transactions should be aborted. The circuit breaker's `Open` state should trigger `txn.abort()` for any pending transactions. Proposed: document this interaction but implement in the circuit breaker RFC.
+
+3. **What happens to exactly-once during hot-reload?** Pipeline schema changes during a transaction could corrupt state. Proposed: drain all in-flight transactions before applying a hot-reload, same as the existing graceful drain mechanism.

--- a/rfcs/rfc-037-stateful-streaming.md
+++ b/rfcs/rfc-037-stateful-streaming.md
@@ -1,0 +1,335 @@
+# RFC-037: Stateful Streaming Modules
+
+**Status:** Draft
+**Priority:** P2 (Streaming Extensibility)
+**Author:** Francisco + Claude
+**Created:** 2026-02-22
+**Depends on:** RFC-025 (Streaming Pipelines), RFC-036 (Delivery Guarantees)
+**Splits from:** RFC-025 Phase 5, Issue #231
+
+---
+
+## Summary
+
+Introduce **stateful streaming modules** — a new module type that maintains per-key mutable state across elements in a streaming pipeline. This enables running counters, session windows, deduplication, and key-based joins without leaving Constellation.
+
+The core abstraction is `StreamModule[S]`: a module that receives an element and its current state, and produces an output element and updated state. The runtime manages state lifecycle: initialization, threading through the stream, periodic checkpointing to a durable backend, and recovery on restart.
+
+---
+
+## Motivation
+
+### The Gap
+
+All current Constellation modules are **stateless** — they receive an input, produce an output, and retain nothing between invocations. In single mode this is fine (each execution is independent). In streaming mode, many real workloads require state:
+
+| Workload | State Needed |
+|----------|-------------|
+| Running count/sum/average | Accumulator per key |
+| Session windows | Per-session buffer + timeout |
+| Deduplication | Seen-set or bloom filter |
+| Key-based joins | Buffer for unmatched elements on each side |
+| Rate limiting | Token bucket per key |
+| Change detection | Previous value per key |
+
+Today, users must implement these as external services (Redis, database) and call them from IO-based modules. This works but loses the benefits of Constellation's type safety, DAG visualization, and lifecycle management.
+
+### What This Enables
+
+```constellation
+in events: Seq<{userId: String, action: String, amount: Float}>
+
+# Stateful module: accumulates spend per user
+userSpend = RunningSum(events, key: userId, value: amount)
+
+# Stateful module: deduplicates by event ID within 1-hour window
+unique = Dedup(events, key: eventId, window: 1h)
+
+# Stateful module: joins two streams by key
+enriched = JoinByKey(orders, users, key: userId)
+
+out userSpend
+out unique
+out enriched
+```
+
+Modules like `RunningSum`, `Dedup`, and `JoinByKey` are implemented using the `StreamModule[S]` trait and can be registered in the stdlib or as user-defined modules.
+
+---
+
+## Design
+
+### Core Trait: `StreamModule[S]`
+
+```scala
+// modules/stream/src/main/scala/io/constellation/stream/StatefulModule.scala
+
+trait StreamModule[S] {
+  /** Initial state for a new key (or on first element if unkeyed). */
+  def initialState: S
+
+  /** Process one element with the current state. Returns output + updated state. */
+  def process(element: CValue, state: S): IO[(CValue, S)]
+
+  /** Serialize state for checkpointing. */
+  def serializeState(state: S): Array[Byte]
+
+  /** Deserialize state on recovery. */
+  def deserializeState(bytes: Array[Byte]): S
+}
+```
+
+### Keyed vs Unkeyed State
+
+| Mode | State Scope | Example |
+|------|-------------|---------|
+| **Unkeyed** | Single global state instance | Global running count |
+| **Keyed** | One state instance per key | Per-user running total |
+
+Keyed state requires a **key extractor** — a function `CValue => String` derived from the pipeline's `key:` parameter. The runtime maintains a `Map[String, S]` of per-key states.
+
+```scala
+case class StatefulModuleConfig[S](
+  module: StreamModule[S],
+  keyExtractor: Option[CValue => String],  // None = unkeyed (global state)
+  checkpointBackend: CheckpointBackend,
+  checkpointInterval: FiniteDuration = 1.minute,
+  stateEvictionPolicy: EvictionPolicy = EvictionPolicy.None
+)
+```
+
+### State Threading in StreamCompiler
+
+For stateless modules, `StreamCompiler` lifts `I => IO[O]` to `stream.evalMap(f)`. For stateful modules, the lifting is different:
+
+```scala
+// Stateless: each element is independent
+stream.evalMap(module.execute)
+
+// Stateful (unkeyed): thread state through elements sequentially
+stream.evalMapAccumulate(initialState) { (state, element) =>
+  module.process(element, state).map { case (output, newState) => (newState, output) }
+}
+
+// Stateful (keyed): maintain per-key state
+stream.evalMap { element =>
+  val key = keyExtractor(element)
+  for {
+    currentState <- stateStore.get(key).map(_.getOrElse(module.initialState))
+    (output, newState) <- module.process(element, currentState)
+    _ <- stateStore.put(key, newState)
+  } yield output
+}
+```
+
+The keyed path requires a **state store** — an abstraction over the mutable state map.
+
+### State Store Abstraction
+
+```scala
+trait StateStore[S] {
+  def get(key: String): IO[Option[S]]
+  def put(key: String, state: S): IO[Unit]
+  def delete(key: String): IO[Unit]
+  def snapshot: IO[Map[String, S]]           // for checkpointing
+  def restore(data: Map[String, S]): IO[Unit] // for recovery
+}
+```
+
+**Implementations:**
+
+| Backend | Persistence | Use Case |
+|---------|-------------|----------|
+| `InMemoryStateStore` | None (lost on restart) | Development, testing, ephemeral streams |
+| `CheckpointedStateStore` | Periodic snapshots to durable storage | Production — wraps in-memory with checkpoint |
+
+The durable storage backend is pluggable:
+
+```scala
+trait CheckpointBackend {
+  def save(streamId: String, moduleId: UUID, data: Array[Byte]): IO[Unit]
+  def load(streamId: String, moduleId: UUID): IO[Option[Array[Byte]]]
+  def delete(streamId: String, moduleId: UUID): IO[Unit]
+}
+```
+
+**Initial backends:**
+
+| Backend | Implementation | Notes |
+|---------|---------------|-------|
+| `FileCheckpointBackend` | Local filesystem | Simple, no dependencies. Good for single-node. |
+| `NoopCheckpointBackend` | No-op | For `InMemoryStateStore` or testing. |
+
+A `RocksDBCheckpointBackend` (referenced in RFC-025) is deferred to a follow-up — it requires a native dependency and careful lifecycle management.
+
+### Checkpointing Protocol
+
+Periodic checkpointing persists state to survive restarts:
+
+```
+Every checkpointInterval:
+  1. Pause element processing (briefly)
+  2. snapshot = stateStore.snapshot()
+  3. bytes = module.serializeState(snapshot)  // per key
+  4. checkpointBackend.save(streamId, moduleId, bytes)
+  5. If at-least-once: commit source offset (state and offset are consistent)
+  6. Resume element processing
+```
+
+**Interaction with delivery guarantees (RFC-036):**
+
+| Guarantee | Checkpoint Behavior |
+|-----------|-------------------|
+| At-most-once | Checkpoint state only; no offset commit |
+| At-least-once | Checkpoint state + commit offset atomically (same interval) |
+| Exactly-once | Checkpoint state + offset within transaction |
+
+Aligning checkpoint and offset commit ensures that on recovery, the replayed elements start from the exact state that was checkpointed. Without this alignment, state and offsets can diverge, causing incorrect results.
+
+### Recovery Protocol
+
+On pipeline restart:
+
+```
+1. Load last checkpoint: bytes = checkpointBackend.load(streamId, moduleId)
+2. Deserialize: stateMap = module.deserializeState(bytes)
+3. Restore: stateStore.restore(stateMap)
+4. Resume source from last committed offset (handled by RFC-036)
+5. Elements between last checkpoint and crash are re-processed
+   → state updates are idempotent (same input + same prior state = same output)
+```
+
+### State Eviction
+
+For keyed state, unbounded key growth is a concern. Eviction policies:
+
+```scala
+sealed trait EvictionPolicy
+object EvictionPolicy {
+  case object None                                   extends EvictionPolicy
+  case class MaxKeys(limit: Int)                     extends EvictionPolicy  // LRU eviction
+  case class TTL(duration: FiniteDuration)            extends EvictionPolicy  // time-based
+  case class TTLAndMaxKeys(ttl: FiniteDuration, max: Int) extends EvictionPolicy
+}
+```
+
+Evicted keys restart with `initialState` on next occurrence.
+
+### Module Registration
+
+Stateful modules are registered like regular modules but with a different builder API:
+
+```scala
+val runningSum: Module.Uninitialized = StreamModuleBuilder
+  .metadata("RunningSum", "Accumulates sum per key", 1, 0)
+  .stateful[Double](
+    initialState = 0.0,
+    process = (element, state) => {
+      val amount = element.asProduct("amount").asFloat
+      val newState = state + amount
+      IO.pure((CValue.CFloat(newState), newState))
+    },
+    serialize = state => state.toString.getBytes,
+    deserialize = bytes => new String(bytes).toDouble
+  )
+  .build
+```
+
+### JoinByKey — First Stateful Stdlib Module
+
+`JoinByKey` is the canonical use case for stateful streaming, and the primary motivation from RFC-025:
+
+```scala
+// State: Map of unmatched elements from each side
+case class JoinState(
+  leftBuffer: Map[String, CValue],   // key → last left element
+  rightBuffer: Map[String, CValue]   // key → last right element
+)
+
+// On left element: buffer it, check right buffer for match
+// On right element: buffer it, check left buffer for match
+// On match: emit joined product, remove from both buffers
+```
+
+This is deferred to a follow-up after the core `StreamModule[S]` infrastructure is proven.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Core `StreamModule[S]` Trait + State Store (~400 LOC)
+
+- [ ] Define `StreamModule[S]` trait
+- [ ] Define `StateStore[S]` trait
+- [ ] Implement `InMemoryStateStore`
+- [ ] Implement `CheckpointedStateStore` wrapper
+- [ ] Define `CheckpointBackend` trait
+- [ ] Implement `FileCheckpointBackend` and `NoopCheckpointBackend`
+- [ ] Unit tests for state store operations and checkpoint round-trip
+
+### Phase 2: StreamCompiler Integration (~300 LOC)
+
+- [ ] Extend `StreamCompiler` to detect stateful modules
+- [ ] Implement unkeyed state threading (`evalMapAccumulate`)
+- [ ] Implement keyed state threading (state store lookup/update)
+- [ ] Wire checkpoint timer into stream lifecycle
+- [ ] Integration tests: stateful module in streaming pipeline
+
+### Phase 3: Key Extraction + Eviction (~200 LOC)
+
+- [ ] Implement key extractor from `key:` parameter in module options
+- [ ] Implement `EvictionPolicy` (LRU, TTL)
+- [ ] Add eviction metrics to `StreamMetrics`
+- [ ] Tests: eviction under load, TTL expiry
+
+### Phase 4: Recovery (~200 LOC)
+
+- [ ] Implement recovery protocol (load checkpoint → restore state → resume)
+- [ ] Align checkpoint interval with offset commit (RFC-036 interaction)
+- [ ] Integration test: crash + restart → state recovered, no data loss
+- [ ] Integration test: state + offset consistency after recovery
+
+### Phase 5: Stdlib Modules (follow-up)
+
+- [ ] `RunningSum` / `RunningAvg` / `RunningCount`
+- [ ] `Dedup` (seen-set with TTL)
+- [ ] `JoinByKey` (buffered key-based join)
+- [ ] `SessionWindow` (per-key windowed aggregation)
+
+---
+
+## Alternatives Considered
+
+### External state via IO-based modules
+
+This is the current workaround — use `.implementation[I, O]` with IO effects that read/write Redis or a database. It works but:
+- State management is the user's responsibility (no automatic checkpointing, recovery, or eviction)
+- No integration with Constellation's delivery guarantees
+- DAG visualization doesn't show state dependencies
+- Hot-reload can't drain state gracefully
+
+`StreamModule[S]` brings state under Constellation's lifecycle management.
+
+### fs2 `evalMapAccumulate` only (no state store)
+
+For unkeyed state, `evalMapAccumulate` is sufficient. But keyed state requires random access by key, which `evalMapAccumulate` doesn't support — it only threads a single accumulator. The state store abstraction is necessary for keyed workloads.
+
+### State serialization via CValue
+
+Instead of user-defined `serializeState`/`deserializeState`, we could require state to be a `CValue` and use the existing CValue serialization. This would simplify the API but limit state to Constellation's type system — no custom data structures, no efficient binary formats. The user-defined approach is more flexible.
+
+### RocksDB from day one
+
+Deferred. RocksDB provides excellent performance for large state stores but adds a native dependency (`librocksdbjni`) and lifecycle complexity (compaction, WAL management). `FileCheckpointBackend` with periodic snapshots is sufficient for initial adoption. RocksDB can be added as a `CheckpointBackend` implementation later without changing the `StreamModule[S]` API.
+
+---
+
+## Open Questions
+
+1. **State schema evolution:** What happens when a stateful module's state type changes (e.g., adding a field to the accumulator)? Options: (a) require explicit migration functions, (b) version the serialization format, (c) discard old state on schema change. Proposed: start with (c) — discard and log a warning. Add migration support in a follow-up if users need it.
+
+2. **Parallelism for keyed state:** Can elements with different keys be processed in parallel? Yes, if the state store supports concurrent access per key. `InMemoryStateStore` with a `ConcurrentHashMap` backend enables this. But ordering within a key must be preserved. Proposed: parallel across keys, sequential within a key.
+
+3. **State size limits:** Should there be a maximum state size per key or per module? Unbounded state growth can OOM the process. Proposed: configurable `maxStateBytes` with a default of 100MB per module, enforced at checkpoint time.
+
+4. **Language syntax for stateful modules:** Should `key:` be a first-class parameter in constellation-lang, or a module option in the `with` clause? Proposed: `with { key: userId }` in the `with` clause, consistent with other module options.


### PR DESCRIPTION
## Summary

Splits RFC-025 Phase 5 into three standalone, independently implementable RFCs:

- **RFC-035: Stream-Level Circuit Breaker** — pauses source consumption on sustained element failures, auto-recovers via half-open probing with exponential backoff cooldown. Builds on existing `StreamEvent.CircuitOpen`/`CircuitClosed` types already defined but never emitted.

- **RFC-036: Delivery Guarantees** — hardens at-least-once (offset commit wiring, fan-out acknowledgment, commit strategies) and introduces exactly-once via a transactional connector SPI with two-phase commit. Includes deployment-time validation that rejects incompatible connector/guarantee combinations.

- **RFC-037: Stateful Streaming Modules** — `StreamModule[S]` trait for keyed/unkeyed mutable state across elements. Covers state stores, checkpointing to durable backends, recovery on restart, eviction policies, and checkpoint/offset alignment with RFC-036.

## Dependency chain

```
RFC-035 (circuit breaker)  ← no blockers, can start immediately
    ↓
RFC-036 (delivery guarantees)  ← depends on 035 for circuit/txn interaction
    ↓
RFC-037 (stateful streaming)  ← depends on 036 for checkpoint/offset alignment
```

## Test plan

- [ ] Review each RFC for completeness and feasibility
- [ ] No code changes — docs only

Ref #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)