### PR TITLE
Fix scalafmt formatting in streaming modules

### DIFF
--- a/modules/http-api/src/main/scala/io/constellation/http/ConstellationRoutes.scala
+++ b/modules/http-api/src/main/scala/io/constellation/http/ConstellationRoutes.scala
@@ -1141,7 +1141,8 @@ class ConstellationRoutes(
         val allInputNames = dagSpec.userInputDataNodes.values.map(_.name).toSet
         val missingNames  = allInputNames -- inputs.keySet
         if missingNames.nonEmpty then {
-          val sig = buildSuspendedSignature(dagSpec, image.structuralHash, inputs, image.moduleOptions)
+          val sig =
+            buildSuspendedSignature(dagSpec, image.structuralHash, inputs, image.moduleOptions)
           IO.pure(Right((sig, dagSpec)))
         } else {
           val loaded = io.constellation.PipelineImage.rehydrate(image)

--- a/modules/http-api/src/main/scala/io/constellation/http/StreamRoutes.scala
+++ b/modules/http-api/src/main/scala/io/constellation/http/StreamRoutes.scala
@@ -256,9 +256,9 @@ class StreamRoutes(
   /** Build a `CValue => IO[CValue]` wrapper for a module using lightweight per-element execution.
     *
     * Instead of calling `Runtime.run` per element (which re-runs validation, scheduler setup,
-    * inline transforms, and state initialization), this directly initializes the module and runs
-    * it with a minimal Runtime — eliminating all unnecessary overhead for single-module synthetic
-    * DAGs in the streaming hot path.
+    * inline transforms, and state initialization), this directly initializes the module and runs it
+    * with a minimal Runtime — eliminating all unnecessary overhead for single-module synthetic DAGs
+    * in the streaming hot path.
     */
   private def buildStreamingModuleFn(
       spec: ModuleNodeSpec,

--- a/modules/stream/src/main/scala/io/constellation/stream/StreamCompiler.scala
+++ b/modules/stream/src/main/scala/io/constellation/stream/StreamCompiler.scala
@@ -126,7 +126,15 @@ object StreamCompiler {
           }
           .build
 
-        wire(dagSpec, resolvedRegistry, modules, options, errorStrategy, joinStrategy, moduleOptions)
+        wire(
+          dagSpec,
+          resolvedRegistry,
+          modules,
+          options,
+          errorStrategy,
+          joinStrategy,
+          moduleOptions
+        )
     }
   }
 

--- a/modules/stream/src/test/scala/io/constellation/stream/StreamCompilerTest.scala
+++ b/modules/stream/src/test/scala/io/constellation/stream/StreamCompilerTest.scala
@@ -606,10 +606,10 @@ class StreamCompilerTest extends AnyFlatSpec with Matchers {
           )
         )
       )
-      _ <- srcQ.offer(Some(CValue.CString("a")))
-      _ <- srcQ.offer(Some(CValue.CString("b")))
-      _ <- srcQ.offer(Some(CValue.CString("c")))
-      _ <- srcQ.offer(None)
+      _     <- srcQ.offer(Some(CValue.CString("a")))
+      _     <- srcQ.offer(Some(CValue.CString("b")))
+      _     <- srcQ.offer(Some(CValue.CString("c")))
+      _     <- srcQ.offer(None)
       _     <- graph.stream.compile.drain
       items <- snkQ.tryTakeN(None)
       snap  <- graph.metrics.snapshot
@@ -648,9 +648,9 @@ class StreamCompilerTest extends AnyFlatSpec with Matchers {
           )
         )
       )
-      _ <- srcQ.offer(Some(CValue.CString("x")))
-      _ <- srcQ.offer(Some(CValue.CString("y")))
-      _ <- srcQ.offer(None)
+      _     <- srcQ.offer(Some(CValue.CString("x")))
+      _     <- srcQ.offer(Some(CValue.CString("y")))
+      _     <- srcQ.offer(None)
       _     <- graph.stream.compile.drain
       items <- snkQ.tryTakeN(None)
     } yield items).unsafeRunSync()


### PR DESCRIPTION
## Summary
- Applies `scalafmt` to 4 files that were failing CI's "Check formatting" step since PR #239 introduced the streaming infrastructure
- No logic changes — formatting only

**Affected files:**
- `StreamCompiler.scala`
- `StreamCompilerTest.scala`
- `StreamRoutes.scala`
- `ConstellationRoutes.scala`

## Test plan
- [x] `sbt stream/compile` — passes
- [x] `sbt stream/Test/compile` — passes
- [x] `sbt httpApi/compile` — passes
- [x] CI formatting check should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)