### PR TITLE
Fix scalafix import ordering in StreamingModuleBenchmark

### DIFF
--- a/modules/http-api/src/test/scala/io/constellation/http/benchmark/StreamingModuleBenchmark.scala
+++ b/modules/http-api/src/test/scala/io/constellation/http/benchmark/StreamingModuleBenchmark.scala
@@ -3,8 +3,8 @@ package io.constellation.http.benchmark
 import java.util.UUID
 
 import cats.Eval
-import cats.effect.{IO, Ref}
 import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref}
 import cats.implicits.*
 
 import io.constellation.*


### PR DESCRIPTION
## Summary
- Fixes import ordering in `StreamingModuleBenchmark.scala` to satisfy scalafix `OrganizeImports` rule
- This was the last CI failure after PR #242 fixed scalafmt

## Test plan
- [x] `sbt "httpApi/Test/scalafixAll --check"` passes locally
- [x] CI should now be fully green

🤖 Generated with [Claude Code](https://claude.com/claude-code)